### PR TITLE
Proof of concept fix for Sonic not being MD2-able

### DIFF
--- a/src/r_things.c
+++ b/src/r_things.c
@@ -2390,6 +2390,12 @@ void R_InitSkins(void)
 	skin->spritedef.numframes = sprites[SPR_PLAY].numframes;
 	skin->spritedef.spriteframes = sprites[SPR_PLAY].spriteframes;
 	ST_LoadFaceGraphics(skin->face, skin->superface, 0);
+	
+	//MD2 for sonic doesn't want to load in Linux.
+#ifdef HWRENDER
+	if (rendermode == render_opengl)
+		HWR_AddPlayerMD2(0);
+#endif	
 }
 
 // returns true if the skin name is found (loaded from pwad)


### PR DESCRIPTION
As reported in http://mb.srb2.org/showthread.php?t=38632, MD2s and Linux don't mix too well.  InitMD2 is called before Sonic's skin can be registered in the Linux build, leading to Sonic's skin not being replacable.  This patch hacks around the problem by calling HWR_AddPlayerMD2 at the end of the function which registers Sonic's skin.  It is not an ideal fix, but it works for now at least.
