### PR TITLE
Make endianess detection more flexible

### DIFF
--- a/src/endian.h
+++ b/src/endian.h
@@ -1,0 +1,45 @@
+// SONIC ROBO BLAST 2
+//-----------------------------------------------------------------------------
+// Copyright (C) 2014 by Sonic Team Junior.
+//
+// This program is free software distributed under the
+// terms of the GNU General Public License, version 2.
+// See the 'LICENSE' file for more details.
+//-----------------------------------------------------------------------------
+/// \file  endian.h
+/// \brief Endian detection
+
+#ifndef __ENDIAN__
+#define __ENDIAN__
+
+#if defined(SRB2_BIG_ENDIAN) || defined(SRB2_LITTLE_ENDIAN)
+  // defined externally
+#else
+  #if defined(__FreeBSD__)
+    // on FreeBSD, _BIG_ENDIAN is a constant to compare
+	// _BYTE_ORDER to, not a big-endianess flag
+    #include <sys/endian.h>
+    #if _BYTE_ORDER == _BIG_ENDIAN
+      #define SRB2_BIG_ENDIAN
+    #else
+      #define SRB2_LITTLE_ENDIAN
+    #endif
+  #elif defined(__BYTE_ORDER__)
+    // defined by at least gcc and clang
+    #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+      #define SRB2_BIG_ENDIAN
+    #else
+      #define SRB2_LITTLE_ENDIAN
+    #endif
+  #else
+    // check used in vanilla SRB2 (may work incorrectly if
+	// _BIG_ENDIAN is used as on FreeBSD)
+    #if defined(_BIG_ENDIAN)
+      #define SRB2_BIG_ENDIAN
+    #else
+      #define SRB2_LITTLE_ENDIAN
+    #endif
+  #endif
+#endif
+
+#endif //__ENDIAN__

--- a/src/m_swap.h
+++ b/src/m_swap.h
@@ -14,9 +14,11 @@
 #ifndef __M_SWAP__
 #define __M_SWAP__
 
+#include "endian.h"
+
 // Endianess handling.
 // WAD files are stored little endian.
-#ifdef _BIG_ENDIAN
+#ifdef SRB2_BIG_ENDIAN
 
 #define SHORT(x) ((INT16)(\
 (((UINT16)(x) & (UINT16)0x00ffU) << 8) \

--- a/src/md5.c
+++ b/src/md5.c
@@ -44,14 +44,9 @@
 
 #include "md5.h"
 
-#ifdef _LIBC
- #include <endian.h>
- #if __BYTE_ORDER == __BIG_ENDIAN
-  #define WORDS_BIGENDIAN 1
- #endif
-#endif
+#include "endian.h"
 
-#if defined (WORDS_BIGENDIAN) || defined (_BIG_ENDIAN)
+#if defined (SRB2_BIG_ENDIAN)
  #define SWAP(n)							\
     (((n) << 24) | (((n) & 0xff00) << 8) | (((n) >> 8) & 0xff00) | ((n) >> 24))
 #else


### PR DESCRIPTION
And fix it on FreeBSD, where _BIG_ENDIAN is not a flag indicating
big endian machine, but a constant to compare _BYTE_ORDER to.
