### PR TITLE
Fix Linux 64-bit crash in CEZ3 (playback of sfx_litng3 [41]).

### DIFF
--- a/src/sdl/mixer_sound.c
+++ b/src/sdl/mixer_sound.c
@@ -152,7 +152,7 @@ static Mix_Chunk *ds2chunk(void *stream)
 		if (!(frac & 0xFFFF)) // other solid multiples (change if FRACBITS != 16)
 			newsamples = samples * (frac >> FRACBITS);
 		else // strange and unusual fractional frequency steps, plus anything higher than 44100hz.
-			newsamples=(samples/freq + 1) *44100 ; //Result of division is not fractional, so 1 is added to ensure a roundup rather than truncation.
+			newsamples = FixedMul(FixedDiv(samples, freq), 44100) + 1; // add 1 to counter truncation.
 		if (newsamples >= UINT32_MAX>>2)
 			return NULL; // would and/or did wrap, can't store.
 		break;


### PR DESCRIPTION
From what I can tell, the crash is due to memory pointer overflow during sample rate conversion on 64-bit when using sdl mixer 1.2.  The simple solution was to increase the "extra samples for security" by one.  Did so, and now there's no crash.  Looks like enough extra memory is being allocated now for there to not be problems on 64-bit.  It's well past midnight, I'm tired, good night and here's hoping someone around here can get that dastardly cage to rise and fall in 64-bit, even if it has to be me.
