### PR TITLE
Makes CEZ3 beatable on Linux64

### DIFF
--- a/src/hardware/hw_main.c
+++ b/src/hardware/hw_main.c
@@ -2857,9 +2857,10 @@ static void HWR_Subsector(size_t num)
 #ifdef DOPLANES
 	// -------------------- WATER IN DEV. TEST ------------------------
 	//dck hack : use abs(tag) for waterheight
-	if (gr_frontsector->tag < 0)
+	//ilag : Since we changed to UINT16 for sector tags, simulate INT16
+	if (gr_frontsector->tag > 32767)
 	{
-		wh = ((-gr_frontsector->tag) <<FRACBITS) + (FRACUNIT/2);
+		wh = ((65535-gr_frontsector->tag) <<FRACBITS) + (FRACUNIT/2);
 		if (wh > gr_frontsector->floorheight &&
 			wh < gr_frontsector->ceilingheight)
 		{

--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -3670,7 +3670,7 @@ static void P_Boss3Thinker(mobj_t *mobj)
 // Move Boss4's sectors by delta.
 static boolean P_Boss4MoveCage(fixed_t delta)
 {
-	const INT16 tag = -2;
+	const UINT16 tag = 65534;
 	INT32 snum;
 	sector_t *sector;
 	for (snum = sectors[tag%numsectors].firsttag; snum != -1; snum = sector->nexttag)
@@ -3719,7 +3719,7 @@ static void P_Boss4PinchSpikeballs(mobj_t *mobj, angle_t angle, fixed_t fz)
 // Destroy cage FOFs.
 static void P_Boss4DestroyCage(void)
 {
-	const INT16 tag = -2;
+	const UINT16 tag = 65534;
 	INT32 snum, next;
 	size_t a;
 	sector_t *sector, *rsec;

--- a/src/r_defs.h
+++ b/src/r_defs.h
@@ -242,7 +242,7 @@ typedef struct sector_s
 	INT32 ceilingpic;
 	INT16 lightlevel;
 	INT16 special;
-	INT16 tag;
+	UINT16 tag;
 	INT32 nexttag, firsttag; // for fast tag searches
 
 	// origin for any sounds played by the sector


### PR DESCRIPTION
The lesson to be learned here: do not cheat and type -2 when you really mean 65534.  Sector tags are now UINT16 in code and tag numbers relating to Boss4's cage are now UINT16s set to 65534.  This change needs testing just in case it screws something else out; I have only tested this in the boss fight itself.
