### PR TITLE
Fix the force shield sprite after invincibility

### DIFF
--- a/src/p_user.c
+++ b/src/p_user.c
@@ -1404,6 +1404,7 @@ void P_SpawnShieldOrb(player_t *player)
 	if (player->powers[pw_shield] & SH_FORCE)
 	{
 		//Copy and pasted from P_ShieldLook in p_mobj.c
+		shieldobj->movecount = (shieldobj->target->player->powers[pw_shield] & 0xFF);
 		if (shieldobj->movecount < 1)
 		{
 			if (shieldobj->info->painstate)


### PR DESCRIPTION
Ensures that the force shield's sprite returns to the proper state after receiving an invincibility monitor.

Fixes http://mb.srb2.org/showthread.php?p=752815
