### PR TITLE
Add LUA_EvalMath to Lua with function name EvalMath

### DIFF
--- a/src/lua_baselib.c
+++ b/src/lua_baselib.c
@@ -85,6 +85,13 @@ static int lib_print(lua_State *L)
 	return 0;
 }
 
+static int lib_evalMath(lua_State *L)
+{
+	const char *word = luaL_checkstring(L, 1);
+	lua_pushinteger(L, LUA_EvalMath(word));
+	return 1;
+}
+
 // M_RANDOM
 //////////////
 
@@ -1633,6 +1640,7 @@ static int lib_gTicsToMilliseconds(lua_State *L)
 
 static luaL_Reg lib[] = {
 	{"print", lib_print},
+	{"EvalMath", lib_evalMath,},
 
 	// m_random
 	{"P_Random",lib_pRandom},


### PR DESCRIPTION
Allows conversion from console inputs of enumerators such as MT_PLAYER into code via Lua.
