### PR TITLE
Some opengl changes, sw performance improvement

### DIFF
--- a/src/sdl2/i_video.c
+++ b/src/sdl2/i_video.c
@@ -224,6 +224,7 @@ static void SDLSetMode(INT32 width, INT32 height, SDL_bool fullscreen)
 	if (rendermode == render_soft)
 	{
 		SDL_RenderSetLogicalSize(renderer, width, height);
+		SDL_RenderClear(renderer);
 		// Set up Texture
 		realwidth = width;
 		realheight = height;


### PR DESCRIPTION
These need to be put into another SDL2 test build so I can see what's causing the Windows build to not get a GL context, if it's not.

Also the ABGR8888 change is a performance improvement for slow CPUs.
