### PR TITLE
Work around myargc getting reset in Linux64 SDL2 [hack]

### DIFF
--- a/src/dehacked.c
+++ b/src/dehacked.c
@@ -350,7 +350,7 @@ static float searchfvalue(const char *s)
 static void clear_conditionsets(void)
 {
 	UINT8 i;
-	for (i = 0; i < MAXCONDITIONSETS; ++i)
+	for (i = 1; i < MAXCONDITIONSETS; ++i)
 		M_ClearConditionSet(i);
 }
 


### PR DESCRIPTION
This probably shouldn't be merged as it's a dirty hack and not a proper fix.

On the Linux64 SDL2 build, when certain wads are placed in the -file command line parameter, myargc gets reset when W_InitMultipleFiles is called in D_SRB2Main.  A known bad wad is SRB2 Hub 1.3 (thread: http://mb.srb2.org/showthread.php?t=38871).  I have no idea why and can't be bothered to dig any deeper now that I found a working hack.  A proper solution would involve figuring out why myargc is being modified when no functions in w_wad.c can access it.

The reason why this matters is because after W_InitMultipleFiles is called, sdl/i_video.c will check for "-opengl", and if myargc is set to 0 the check fails and opengl won't be enabled.