### PR TITLE
Merge the dedicatedserver and server global variables

### DIFF
--- a/src/dehacked.c
+++ b/src/dehacked.c
@@ -8681,12 +8681,7 @@ static inline int lib_getenum(lua_State *L)
 		lua_pushinteger(L, mapmusic);
 		return 1;
 	} else if (fastcmp(word,"server")) {
-		if (dedicated || !playeringame[serverplayer])
-			return 0;
-		LUA_PushUserdata(L, &players[serverplayer], META_PLAYER);
-		return 1;
-	} else if (fastcmp(word,"dedicatedserver")) {
-		if (!dedicated)
+		if (!playeringame[serverplayer])
 			return 0;
 		LUA_PushUserdata(L, &players[serverplayer], META_PLAYER);
 		return 1;


### PR DESCRIPTION
Previously in Lua, dedicatedserver would only return a player_t if the player running the script was the one hosting the dedicated server. In all other cases, it would return nil. This fixes it to point to the server host no matter what.
