### PR TITLE
Change super transformation to freeze momentum instead of bitshifting

### DIFF
--- a/src/p_user.c
+++ b/src/p_user.c
@@ -973,9 +973,7 @@ void P_DoSuperTransformation(player_t *player, boolean giverings)
 	// Transformation animation
 	P_SetPlayerMobjState(player->mo, S_PLAY_SUPERTRANS1);
 
-	player->mo->momx >>= 1;
-	player->mo->momy >>= 1;
-	player->mo->momz >>= 1;
+	player->mo->momx = player->mo->momy = player->mo->momz = 0;
 
 	if (giverings)
 	{


### PR DESCRIPTION
Fixes https://mb.srb2.org/showthread.php?t=39921 where the issue before was that when you transformed your momentum would still have you moving slowly, which could cancel out the animation.
