### PR TITLE
Disable LFS on 32-Bit Linux boxes

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -305,7 +305,7 @@ PNG_LDFLAGS?=$(shell $(PNG_CONFIG) --ldflags)
 endif
 endif
 
-ifdef LINUX
+ifdef LINUX64
 PNG_CFLAGS+=-D_LARGEFILE64_SOURCE
 endif
 


### PR DESCRIPTION
Disable LFS on 32-Bit Linux boxes to prevent ```off64_t' undeclared```