### PR TITLE
Make sure "word" in readlevelheader gets reset

### DIFF
--- a/src/dehacked.c
+++ b/src/dehacked.c
@@ -998,7 +998,7 @@ static const struct {
 static void readlevelheader(MYFILE *f, INT32 num)
 {
 	char *s = Z_Malloc(MAXLINELEN, PU_STATIC, NULL);
-	char *word = s;
+	char *word;
 	char *word2;
 	//char *word3; // Non-uppercase version of word2
 	char *tmp;
@@ -1026,6 +1026,9 @@ static void readlevelheader(MYFILE *f, INT32 num)
 				*tmp = '\0';
 			if (s == tmp)
 				continue; // Skip comment lines, but don't break.
+
+			// Set / reset word, because some things (Lua.) move it
+			word = s;
 
 			// Get the part before the " = "
 			tmp = strchr(s, '=');


### PR DESCRIPTION
... because some things (Lua. custom header entries) move it.
https://mb.srb2.org/showthread.php?t=40580

(Technically breaks netgame compatibility for Lua-heavy mods, so in next.)