### PR TITLE
Fix chain launching

### DIFF
--- a/src/p_inter.c
+++ b/src/p_inter.c
@@ -1339,6 +1339,9 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher, boolean heightcheck)
 			}
 			else
 				player->pflags |= PF_ITEMHANG;
+
+			// Can't jump first frame
+			player->pflags |= PF_JUMPSTASIS;
 			return;
 		case MT_BIGMINE:
 		case MT_BIGAIRMINE:

--- a/src/p_user.c
+++ b/src/p_user.c
@@ -6340,8 +6340,7 @@ static void P_MovePlayer(player_t *player)
 		if (!(player->powers[pw_nocontrol] & (1<<15)))
 			player->pflags |= PF_JUMPSTASIS;
 	}
-	else
-		player->pflags &= ~PF_FULLSTASIS;
+	// note: don't unset stasis here
 
 	if (!player->spectator && G_TagGametype())
 	{
@@ -8927,6 +8926,11 @@ void P_PlayerThink(player_t *player)
 
 	if (!player->mo)
 		return; // P_MovePlayer removed player->mo.
+
+	// Unset statis flags after moving.
+	// In other words, if you manually set stasis via code,
+	// it lasts for one tic.
+	player->pflags &= ~PF_FULLSTASIS;
 
 #ifdef POLYOBJECTS
 	if (player->onconveyor == 1)


### PR DESCRIPTION
Basically you're not allowed to launch off a chain the frame you touch it anymore.

Coincidentally the changes here allow you to actually use `PF_*STASIS` in a Lua script now and have it work as you'd expect it to (it lasts for a tic).