### PR TITLE
Version constants for Lua

### DIFF
--- a/src/dehacked.c
+++ b/src/dehacked.c
@@ -6941,6 +6941,8 @@ struct {
 	{"PUSHACCEL",PUSHACCEL},
 	{"MODID",MODID}, // I don't know, I just thought it would be cool for a wad to potentially know what mod it was loaded into.
 	{"CODEBASE",CODEBASE}, // or what release of SRB2 this is.
+	{"VERSION",VERSION}, // Grab the game's version!
+	{"SUBVERSION",SUBVERSION}, // more precise version number
 
 	// Special linedef executor tag numbers!
 	{"LE_PINCHPHASE",LE_PINCHPHASE}, // A boss entered pinch phase (and, in most cases, is preparing their pinch phase attack!)
@@ -8212,6 +8214,9 @@ static inline int lib_getenum(lua_State *L)
 		return 1;
 	} else if (fastcmp(word,"gravity")) {
 		lua_pushinteger(L, gravity);
+		return 1;
+	} else if (fastcmp(word,"VERSIONSTRING")) {
+		lua_pushstring(L, VERSIONSTRING);
 		return 1;
 	}
 


### PR DESCRIPTION
Pretty simple thing. Allows scripters to use VERSION, SUBVERSION, and VERSIONSTRING to check the game's version and potentially futureproof scripts. Have tested and confirmed working on my end.