### PR TITLE
Crashfix Lua hook_NetVars

### DIFF
--- a/src/lua_hooklib.c
+++ b/src/lua_hooklib.c
@@ -779,15 +779,21 @@ void LUAh_NetArchiveHook(lua_CFunction archFunc)
 	I_Assert(lua_gettop(gL) > 0);
 	I_Assert(lua_istable(gL, -1));
 
+	// tables becomes an upvalue of archFunc
+	lua_pushvalue(gL, -1);
+	lua_pushcclosure(gL, archFunc, 1);
+	// stack: tables, archFunc
+
 	for (hookp = roothook; hookp; hookp = hookp->next)
 		if (hookp->type == hook_NetVars)
 		{
 			lua_pushfstring(gL, FMT_HOOKID, hookp->id);
 			lua_gettable(gL, LUA_REGISTRYINDEX);
-			lua_pushvalue(gL, -2); // tables
+			lua_pushvalue(gL, -2); // archFunc
 			LUA_Call(gL, 1);
 		}
 
+	lua_pop(gL, 1); // pop archFunc
 	// stack: tables
 }
 

--- a/src/lua_hooklib.c
+++ b/src/lua_hooklib.c
@@ -768,4 +768,28 @@ boolean LUAh_HurtMsg(player_t *player, mobj_t *inflictor, mobj_t *source)
 	return hooked;
 }
 
+void LUAh_NetArchiveHook(lua_CFunction archFunc)
+{
+	hook_p hookp;
+
+	if (!gL || !(hooksAvailable[hook_NetVars/8] & (1<<(hook_NetVars%8))))
+		return;
+
+	// stack: tables
+	I_Assert(lua_gettop(gL) > 0);
+	I_Assert(lua_istable(gL, -1));
+
+	for (hookp = roothook; hookp; hookp = hookp->next)
+		if (hookp->type == hook_NetVars)
+		{
+			lua_pushfstring(gL, FMT_HOOKID, hookp->id);
+			lua_gettable(gL, LUA_REGISTRYINDEX);
+			lua_pushvalue(gL, -2); // tables
+			LUA_Call(gL, 1);
+		}
+
+	// pop tables
+	lua_pop(gL, 1);
+}
+
 #endif

--- a/src/lua_hooklib.c
+++ b/src/lua_hooklib.c
@@ -24,6 +24,8 @@
 #include "lua_hook.h"
 #include "lua_hud.h" // hud_running errors
 
+void LUAh_NetArchiveHook(lua_CFunction archFunc);
+
 static UINT8 hooksAvailable[(hook_MAX/8)+1];
 
 const char *const hookNames[hook_MAX+1] = {

--- a/src/lua_hooklib.c
+++ b/src/lua_hooklib.c
@@ -788,8 +788,7 @@ void LUAh_NetArchiveHook(lua_CFunction archFunc)
 			LUA_Call(gL, 1);
 		}
 
-	// pop tables
-	lua_pop(gL, 1);
+	// stack: tables
 }
 
 #endif

--- a/src/lua_hooklib.c
+++ b/src/lua_hooklib.c
@@ -24,8 +24,6 @@
 #include "lua_hook.h"
 #include "lua_hud.h" // hud_running errors
 
-void LUAh_NetArchiveHook(lua_CFunction archFunc);
-
 static UINT8 hooksAvailable[(hook_MAX/8)+1];
 
 const char *const hookNames[hook_MAX+1] = {

--- a/src/lua_script.c
+++ b/src/lua_script.c
@@ -915,29 +915,7 @@ static void UnArchiveTables(void)
 	}
 }
 
-static void NetArchiveHook(lua_CFunction archFunc)
-{
-	int TABLESINDEX;
-
-	if (!gL)
-		return;
-
-	TABLESINDEX = lua_gettop(gL);
-	lua_getfield(gL, LUA_REGISTRYINDEX, "hook");
-	I_Assert(lua_istable(gL, -1));
-	lua_rawgeti(gL, -1, hook_NetVars);
-	lua_remove(gL, -2);
-	I_Assert(lua_istable(gL, -1));
-
-	lua_pushvalue(gL, TABLESINDEX);
-	lua_pushcclosure(gL, archFunc, 1);
-	lua_pushnil(gL);
-	while (lua_next(gL, -3) != 0) {
-		lua_pushvalue(gL, -3); // function
-		LUA_Call(gL, 1);
-	}
-	lua_pop(gL, 2);
-}
+void LUAh_NetArchiveHook(lua_CFunction archFunc);
 
 void LUA_Step(void)
 {
@@ -972,7 +950,7 @@ void LUA_Archive(void)
 		}
 	WRITEUINT32(save_p, UINT32_MAX); // end of mobjs marker, replaces mobjnum.
 
-	NetArchiveHook(NetArchive); // call the NetArchive hook in archive mode
+	LUAh_NetArchiveHook(NetArchive); // call the NetArchive hook in archive mode
 	ArchiveTables();
 
 	if (gL)
@@ -1003,7 +981,7 @@ void LUA_UnArchive(void)
 				UnArchiveExtVars(th); // apply variables
 	} while(mobjnum != UINT32_MAX); // repeat until end of mobjs marker.
 
-	NetArchiveHook(NetUnArchive); // call the NetArchive hook in unarchive mode
+	LUAh_NetArchiveHook(NetUnArchive); // call the NetArchive hook in unarchive mode
 	UnArchiveTables();
 
 	if (gL)

--- a/src/lua_script.c
+++ b/src/lua_script.c
@@ -915,8 +915,6 @@ static void UnArchiveTables(void)
 	}
 }
 
-void LUAh_NetArchiveHook(lua_CFunction archFunc);
-
 void LUA_Step(void)
 {
 	if (!gL)

--- a/src/lua_script.h
+++ b/src/lua_script.h
@@ -55,6 +55,7 @@ void Got_Luacmd(UINT8 **cp, INT32 playernum); // lua_consolelib.c
 void LUA_CVarChanged(const char *name); // lua_consolelib.c
 int Lua_optoption(lua_State *L, int narg,
 	const char *def, const char *const lst[]);
+void LUAh_NetArchiveHook(lua_CFunction archFunc);
 
 // Console wrapper
 void COM_Lua_f(void);


### PR DESCRIPTION
Updated NetArchiveHook to new lua_hooklib.c standards.

Fixes I_Assert failure crash due to hooks working differently in next.