### PR TITLE
Ceiling lighting fix

### DIFF
--- a/src/r_segs.c
+++ b/src/r_segs.c
@@ -1922,7 +1922,7 @@ void R_StoreWallRange(INT32 start, INT32 stop)
 		    || backsector->ceilingpic_angle != frontsector->ceilingpic_angle
 		    //SoM: 3/22/2000: Prevents bleeding.
 		    || (frontsector->heightsec != -1 && frontsector->ceilingpic != skyflatnum)
-		    || backsector->floorlightsec != frontsector->floorlightsec
+		    || backsector->ceilinglightsec != frontsector->ceilinglightsec
 		    //SoM: 4/3/2000: Check for colormaps
 		    || frontsector->extra_colormap != backsector->extra_colormap
 		    || (frontsector->ffloors != backsector->ffloors && frontsector->tag != backsector->tag))


### PR DESCRIPTION
The ceiling lighting linedef special (and anything else that changes ceiling lighting directly for sectors) works in software mode now.