### PR TITLE
Fix portal and plane/sky interaction

### DIFF
--- a/src/r_plane.c
+++ b/src/r_plane.c
@@ -475,7 +475,8 @@ visplane_t *R_FindPlane(fixed_t height, INT32 picnum, INT32 lightlevel,
 			&& lightlevel == check->lightlevel
 			&& xoff == check->xoffs && yoff == check->yoffs
 			&& planecolormap == check->extra_colormap
-			&& !pfloor && !check->ffloor && check->viewz == viewz
+			&& !pfloor && !check->ffloor
+			&& check->viewx == viewx && check->viewy == viewy && check->viewz == viewz
 			&& check->viewangle == viewangle
 #ifdef ESLOPE
 			&& check->slope == slope
@@ -497,6 +498,8 @@ visplane_t *R_FindPlane(fixed_t height, INT32 picnum, INT32 lightlevel,
 	check->yoffs = yoff;
 	check->extra_colormap = planecolormap;
 	check->ffloor = pfloor;
+	check->viewx = viewx;
+	check->viewy = viewy;
 	check->viewz = viewz;
 	check->viewangle = viewangle + plangle;
 	check->plangle = plangle;
@@ -567,6 +570,8 @@ visplane_t *R_CheckPlane(visplane_t *pl, INT32 start, INT32 stop)
 		new_pl->yoffs = pl->yoffs;
 		new_pl->extra_colormap = pl->extra_colormap;
 		new_pl->ffloor = pl->ffloor;
+		new_pl->viewx = pl->viewx;
+		new_pl->viewy = pl->viewy;
 		new_pl->viewz = pl->viewz;
 		new_pl->viewangle = pl->viewangle;
 		new_pl->plangle = pl->plangle;
@@ -954,11 +959,11 @@ void R_DrawSinglePlane(visplane_t *pl)
 		xoffs *= fudge;
 		yoffs /= fudge;
 
-		vx = FIXED_TO_FLOAT(viewx+xoffs);
-		vy = FIXED_TO_FLOAT(viewy-yoffs);
-		vz = FIXED_TO_FLOAT(viewz);
+		vx = FIXED_TO_FLOAT(pl->viewx+xoffs);
+		vy = FIXED_TO_FLOAT(pl->viewy-yoffs);
+		vz = FIXED_TO_FLOAT(pl->viewz);
 
-		temp = P_GetZAt(pl->slope, viewx, viewy);
+		temp = P_GetZAt(pl->slope, pl->viewx, pl->viewy);
 		zeroheight = FIXED_TO_FLOAT(temp);
 
 #define ANG2RAD(angle) ((float)((angle)*M_PI)/ANGLE_180)
@@ -982,9 +987,9 @@ void R_DrawSinglePlane(visplane_t *pl)
 		n.z = -cos(ang);
 
 		ang = ANG2RAD(pl->plangle);
-		temp = P_GetZAt(pl->slope, viewx + FLOAT_TO_FIXED(sin(ang)), viewy + FLOAT_TO_FIXED(cos(ang)));
+		temp = P_GetZAt(pl->slope, pl->viewx + FLOAT_TO_FIXED(sin(ang)), pl->viewy + FLOAT_TO_FIXED(cos(ang)));
 		m.y = FIXED_TO_FLOAT(temp) - zeroheight;
-		temp = P_GetZAt(pl->slope, viewx + FLOAT_TO_FIXED(cos(ang)), viewy - FLOAT_TO_FIXED(sin(ang)));
+		temp = P_GetZAt(pl->slope, pl->viewx + FLOAT_TO_FIXED(cos(ang)), pl->viewy - FLOAT_TO_FIXED(sin(ang)));
 		n.y = FIXED_TO_FLOAT(temp) - zeroheight;
 
 		m.x /= fudge;
@@ -1039,6 +1044,14 @@ void R_DrawSinglePlane(visplane_t *pl)
 	pl->bottom[pl->minx-1] = 0x0000;
 
 	stop = pl->maxx + 1;
+
+	if (viewx != pl->viewx || viewy != pl->viewy)
+	{
+		viewx = pl->viewx;
+		viewy = pl->viewy;
+	}
+	if (viewz != pl->viewz)
+		viewz = pl->viewz;
 
 	for (x = pl->minx; x <= stop; x++)
 	{

--- a/src/r_plane.c
+++ b/src/r_plane.c
@@ -299,7 +299,7 @@ void R_MapPlane(INT32 y, INT32 x1, INT32 x2)
 	}
 
 	length = FixedMul (distance,distscale[x1]);
-	angle = (viewangle + xtoviewangle[x1])>>ANGLETOFINESHIFT;
+	angle = (currentplane->viewangle + currentplane->plangle + xtoviewangle[x1])>>ANGLETOFINESHIFT;
 	/// \note Wouldn't it be faster just to add viewx and viewy
 	// to the plane's x/yoffs anyway??
 
@@ -970,14 +970,14 @@ void R_DrawSinglePlane(visplane_t *pl)
 		// p is the texture origin in view space
 		// Don't add in the offsets at this stage, because doing so can result in
 		// errors if the flat is rotated.
-		ang = ANG2RAD(ANGLE_270 - viewangle);
+		ang = ANG2RAD(ANGLE_270 - pl->viewangle);
 		p.x = vx * cos(ang) - vy * sin(ang);
 		p.z = vx * sin(ang) + vy * cos(ang);
 		temp = P_GetZAt(pl->slope, -xoffs, yoffs);
 		p.y = FIXED_TO_FLOAT(temp) - vz;
 
 		// m is the v direction vector in view space
-		ang = ANG2RAD(ANGLE_180 - pl->viewangle);
+		ang = ANG2RAD(ANGLE_180 - (pl->viewangle + pl->plangle));
 		m.x = cos(ang);
 		m.z = sin(ang);
 

--- a/src/r_plane.c
+++ b/src/r_plane.c
@@ -299,7 +299,7 @@ void R_MapPlane(INT32 y, INT32 x1, INT32 x2)
 	}
 
 	length = FixedMul (distance,distscale[x1]);
-	angle = (currentplane->viewangle + xtoviewangle[x1])>>ANGLETOFINESHIFT;
+	angle = (viewangle + xtoviewangle[x1])>>ANGLETOFINESHIFT;
 	/// \note Wouldn't it be faster just to add viewx and viewy
 	// to the plane's x/yoffs anyway??
 
@@ -501,7 +501,7 @@ visplane_t *R_FindPlane(fixed_t height, INT32 picnum, INT32 lightlevel,
 	check->viewx = viewx;
 	check->viewy = viewy;
 	check->viewz = viewz;
-	check->viewangle = viewangle + plangle;
+	check->viewangle = viewangle;
 	check->plangle = plangle;
 #ifdef POLYOBJECTS_PLANES
 	check->polyobj = NULL;
@@ -670,7 +670,6 @@ void R_MakeSpans(INT32 x, INT32 t1, INT32 b1, INT32 t2, INT32 b2)
 void R_DrawPlanes(void)
 {
 	visplane_t *pl;
-	angle_t skyviewangle = viewangle; // the flat angle itself can mess with viewangle, so do your own angle instead!
 	INT32 x;
 	INT32 angle;
 	INT32 i;
@@ -709,7 +708,7 @@ void R_DrawPlanes(void)
 
 					if (dc_yl <= dc_yh)
 					{
-						angle = (skyviewangle + xtoviewangle[x])>>ANGLETOSKYSHIFT;
+						angle = (pl->viewangle + xtoviewangle[x])>>ANGLETOSKYSHIFT;
 						dc_x = x;
 						dc_source =
 							R_GetColumn(skytexture,
@@ -862,13 +861,13 @@ void R_DrawSinglePlane(visplane_t *pl)
 #ifdef ESLOPE
 	if (!pl->slope) // Don't mess with angle on slopes! We'll handle this ourselves later
 #endif
-	if (viewangle != pl->viewangle)
+	if (viewangle != pl->viewangle+pl->plangle)
 	{
 		memset(cachedheight, 0, sizeof (cachedheight));
-		angle = (pl->viewangle-ANGLE_90)>>ANGLETOFINESHIFT;
+		angle = (pl->viewangle+pl->plangle-ANGLE_90)>>ANGLETOFINESHIFT;
 		basexscale = FixedDiv(FINECOSINE(angle),centerxfrac);
 		baseyscale = -FixedDiv(FINESINE(angle),centerxfrac);
-		viewangle = pl->viewangle;
+		viewangle = pl->viewangle+pl->plangle;
 	}
 
 	currentplane = pl;
@@ -978,7 +977,7 @@ void R_DrawSinglePlane(visplane_t *pl)
 		p.y = FIXED_TO_FLOAT(temp) - vz;
 
 		// m is the v direction vector in view space
-		ang = ANG2RAD(ANGLE_180 - viewangle - pl->plangle);
+		ang = ANG2RAD(ANGLE_180 - pl->viewangle);
 		m.x = cos(ang);
 		m.z = sin(ang);
 

--- a/src/r_plane.h
+++ b/src/r_plane.h
@@ -27,7 +27,8 @@ typedef struct visplane_s
 {
 	struct visplane_s *next;
 
-	fixed_t height, viewz;
+	fixed_t height;
+	fixed_t viewx, viewy, viewz;
 	angle_t viewangle;
 	angle_t plangle;
 	INT32 picnum;


### PR DESCRIPTION
More portal-related fixes:

- Fixes rendering issue 4 from issue [#21](http://git.magicalgirl.moe/STJr/SRB2/issues/21) (Slope planes render with wrong height values when visportals are visible on-screen)
- Fixes sky rendering through portals, so that the sky you see through each portal is what you'd expect to see if you were actually there. Easiest way to see what I mean is through sky 22's planet, in a map with portals at 90 degrees to the other sides respectively (the example map on the wiki for ld40, for instance).