### PR TITLE
Nights hotfix

### DIFF
--- a/src/p_user.c
+++ b/src/p_user.c
@@ -4952,8 +4952,9 @@ static void P_NightsTransferPoints(player_t *player, fixed_t xspeed, fixed_t rad
 	else
 	{
 		const angle_t fa = player->angle_pos>>ANGLETOFINESHIFT;
-		player->mo->momx = player->mo->target->x + FixedMul(FINECOSINE(fa),radius) - player->mo->x;
-		player->mo->momy = player->mo->target->y + FixedMul(FINESINE(fa),radius) - player->mo->y;
+		const angle_t faold = player->old_angle_pos>>ANGLETOFINESHIFT;
+		player->mo->momx = FixedMul(FINECOSINE(fa),radius) - FixedMul(FINECOSINE(faold),radius);
+		player->mo->momy = FixedMul(FINESINE(fa),radius) - FixedMul(FINESINE(faold),radius);
 	}
 
 	if (player->exiting)


### PR DESCRIPTION
Fixes the following issues relating to playing as NiGHTS Super Sonic that apparently popped up between 2.1.14 and next (mostly due to the changes to SRB2's trig stuff it seems):

- Super Sonic drifts to the side at some angles around an axis, and is unable to go directly upwards or downwards as a result
- Drilling to the side when on the ground causes the drill sound to constantly restart
- CEZS's start not actually being on the first axis means the player is not able to go backwards along the track (because the player is not actually aligned with the track properly)
- trying to hug some walls such as the tall wall before the library section of CEZS allows Super Sonic to go through them

These fixes needs proper testing before this branch can be merged in, in case they accidentally break other things as a result or something.