### PR TITLE
Some SDL-related compiling tweaks

### DIFF
--- a/src/win32/Makefile.cfg
+++ b/src/win32/Makefile.cfg
@@ -9,14 +9,14 @@
 ifdef MINGW64
 	NOASM=1
 	NONX86=1
-	SDL_CFLAGS?=-I../libs/SDL2/x86_64-w64-mingw32/include/SDL2 -I../libs/SDL2_mixer/x86_64-w64-mingw32/include/SDL2 -Dmain=SDL_main -DSDLMAIN
-	SDL_LDFLAGS?=-L../libs/SDL2/x86_64-w64-mingw32/lib -L../libs/SDL2_mixer/x86_64-w64-mingw32/lib -lmingw32 -lSDL2main -lSDL2 -mwindows  -lSDL2_mixer
+	SDL_CFLAGS?=-I../libs/SDL2/x86_64-w64-mingw32/include/SDL2 -I../libs/SDL2_mixer/x86_64-w64-mingw32/include/SDL2 -Dmain=SDL_main
+	SDL_LDFLAGS?=-L../libs/SDL2/x86_64-w64-mingw32/lib -L../libs/SDL2_mixer/x86_64-w64-mingw32/lib -lmingw32 -lSDL2main -lSDL2 -mwindows
 else
 	HAVE_LIBGME=1
 	LIBGME_CFLAGS=-I../libs/gme/include
 	LIBGME_LDFLAGS=-L../libs/gme/win32 -lgme
-	SDL_CFLAGS?=-I../libs/SDL2/i686-w64-mingw32/include/SDL2 -I../libs/SDL2_mixer/i686-w64-mingw32/include/SDL2 -Dmain=SDL_main -DSDLMAIN
-	SDL_LDFLAGS?=-L../libs/SDL2/i686-w64-mingw32/lib -L../libs/SDL2_mixer/i686-w64-mingw32/lib -lmingw32 -lSDL2main -lSDL2 -mwindows  -lSDL2_mixer
+	SDL_CFLAGS?=-I../libs/SDL2/i686-w64-mingw32/include/SDL2 -I../libs/SDL2_mixer/i686-w64-mingw32/include/SDL2 -Dmain=SDL_main
+	SDL_LDFLAGS?=-L../libs/SDL2/i686-w64-mingw32/lib -L../libs/SDL2_mixer/i686-w64-mingw32/lib -lmingw32 -lSDL2main -lSDL2 -mwindows
 endif
 
 ifndef NOASM


### PR DESCRIPTION
The following things are already dealt with in sdl/Makefile.cfg I'm pretty sure:

* -lSDL2_mixer is already added to SDL_LDFLAGS by default, unless NOMIXER=1 is set
* -DSDLMAIN should also be added to OPTS by default for MINGW=1 builds, unless NOSDLMAIN=1 is set

Just making this branch here on GitHub so Alam can make sure it's all fine and stuff I suppose?