### PR TITLE
Some other software fixes/changes

### DIFF
--- a/src/r_segs.c
+++ b/src/r_segs.c
@@ -2483,6 +2483,15 @@ void R_StoreWallRange(INT32 start, INT32 stop)
 #ifdef ESLOPE
 			maskedtextureheight = ds_p->maskedtextureheight; // note to red, this == &(ds_p->maskedtextureheight[0])
 
+#ifdef POLYOBJECTS
+			if (curline->polyseg) { // use REAL front and back floors please, so midtexture rendering isn't mucked up
+				rw_midtextureslide = rw_midtexturebackslide = 0;
+				if (!!(linedef->flags & ML_DONTPEGBOTTOM) ^ !!(linedef->flags & ML_EFFECT3))
+					rw_midtexturemid = rw_midtextureback = max(curline->frontsector->floorheight, curline->backsector->floorheight) - viewz;
+				else
+					rw_midtexturemid = rw_midtextureback = min(curline->frontsector->ceilingheight, curline->backsector->ceilingheight) - viewz;
+			} else
+#endif
 			// Set midtexture starting height
 			if (linedef->flags & ML_EFFECT2) { // Ignore slopes when texturing
 				rw_midtextureslide = rw_midtexturebackslide = 0;

--- a/src/r_segs.c
+++ b/src/r_segs.c
@@ -1858,7 +1858,7 @@ void R_StoreWallRange(INT32 start, INT32 stop)
 		// a single sided line is terminal, so it must mark ends
 		markfloor = markceiling = true;
 #ifdef ESLOPE
-		if (!(linedef->flags & ML_EFFECT1)) {
+		if (linedef->flags & ML_EFFECT2) {
 			if (linedef->flags & ML_DONTPEGBOTTOM)
 				rw_midtexturemid = frontsector->floorheight + textureheight[sidedef->midtexture] - viewz;
 			else

--- a/src/r_segs.c
+++ b/src/r_segs.c
@@ -1862,8 +1862,9 @@ void R_StoreWallRange(INT32 start, INT32 stop)
 			if (linedef->flags & ML_DONTPEGBOTTOM)
 				rw_midtexturemid = frontsector->floorheight + textureheight[sidedef->midtexture] - viewz;
 			else
-				rw_midtexturemid = frontsector->ceilingheight;
+				rw_midtexturemid = frontsector->ceilingheight - viewz;
 		}
+		else
 #endif
 		if (linedef->flags & ML_DONTPEGBOTTOM)
 		{


### PR DESCRIPTION
Some other software fixes/changes I've made

* Change 1: single-sided linedef midtextures (read: not double-sided linedefs, but single-sided) now don't skew if Effect 2 is checked. Before, there wasn't any ability for software to disable skewing for them. =V
* Change 2: PolyObject back side midtextures now return to being where they should be. Had to make a hack to fix this though.