### PR TITLE
Fixes and changes related to the act of setting up a level (in other words, setup fixes)

### DIFF
--- a/src/p_setup.c
+++ b/src/p_setup.c
@@ -1977,6 +1977,31 @@ static void P_GroupLines(void)
 	}
 }
 
+//
+// P_LoadReject
+//
+// Detect if the REJECT lump is valid,
+// if not, rejectmatrix will be NULL
+static void P_LoadReject(lumpnum_t lumpnum)
+{
+	size_t count;
+	const char *lumpname = W_CheckNameForNum(lumpnum);
+
+	// Check if the lump exists, and if it's named "REJECT"
+	if (!lumpname || memcmp(lumpname, "REJECT", 8) != 0)
+	{
+		rejectmatrix = NULL;
+		return;
+	}
+
+	count = W_LumpLength(lumpnum);
+
+	if (!count) // zero length, someone probably used ZDBSP
+		rejectmatrix = NULL;
+	else
+		rejectmatrix = W_CacheLumpNum(lumpnum, PU_LEVEL);
+}
+
 #if 0
 static char *levellumps[] =
 {
@@ -2585,7 +2610,7 @@ boolean P_SetupLevel(boolean skipprecip)
 	P_LoadSubsectors(lastloadedmaplumpnum + ML_SSECTORS);
 	P_LoadNodes(lastloadedmaplumpnum + ML_NODES);
 	P_LoadSegs(lastloadedmaplumpnum + ML_SEGS);
-	rejectmatrix = W_CacheLumpNum(lastloadedmaplumpnum + ML_REJECT, PU_LEVEL);
+	P_LoadReject(lastloadedmaplumpnum + ML_REJECT);
 	P_GroupLines();
 
 	numdmstarts = numredctfstarts = numbluectfstarts = 0;

--- a/src/p_setup.c
+++ b/src/p_setup.c
@@ -1988,7 +1988,7 @@ static void P_LoadReject(lumpnum_t lumpnum)
 	const char *lumpname = W_CheckNameForNum(lumpnum);
 
 	// Check if the lump exists, and if it's named "REJECT"
-	if (!lumpname || memcmp(lumpname, "REJECT", 8) != 0)
+	if (!lumpname || memcmp(lumpname, "REJECT", 5) != 0)
 	{
 		rejectmatrix = NULL;
 		return;

--- a/src/p_setup.c
+++ b/src/p_setup.c
@@ -1988,7 +1988,7 @@ static void P_LoadReject(lumpnum_t lumpnum)
 	const char *lumpname = W_CheckNameForNum(lumpnum);
 
 	// Check if the lump exists, and if it's named "REJECT"
-	if (!lumpname || memcmp(lumpname, "REJECT", 7) != 0)
+	if (!lumpname || memcmp(lumpname, "REJECT\0\0", 8) != 0)
 	{
 		rejectmatrix = NULL;
 		return;

--- a/src/p_setup.c
+++ b/src/p_setup.c
@@ -1988,7 +1988,7 @@ static void P_LoadReject(lumpnum_t lumpnum)
 	const char *lumpname = W_CheckNameForNum(lumpnum);
 
 	// Check if the lump exists, and if it's named "REJECT"
-	if (!lumpname || memcmp(lumpname, "REJECT", 5) != 0)
+	if (!lumpname || memcmp(lumpname, "REJECT", 7) != 0)
 	{
 		rejectmatrix = NULL;
 		return;

--- a/src/p_setup.c
+++ b/src/p_setup.c
@@ -1931,10 +1931,18 @@ static void P_GroupLines(void)
 	// allocate linebuffers for each sector
 	for (i = 0, sector = sectors; i < numsectors; i++, sector++)
 	{
-		sector->lines = Z_Calloc(sector->linecount * sizeof(line_t*), PU_LEVEL, NULL);
+		if (sector->linecount == 0) // no lines found?
+		{
+			sector->lines = NULL;
+			CONS_Debug(DBG_SETUP, "P_GroupLines: sector %d has no lines\n", i);
+		}
+		else
+		{
+			sector->lines = Z_Calloc(sector->linecount * sizeof(line_t*), PU_LEVEL, NULL);
 
-		// zero the count, since we'll later use this to track how many we've recorded
-		sector->linecount = 0;
+			// zero the count, since we'll later use this to track how many we've recorded
+			sector->linecount = 0;
+		}
 	}
 
 	// iterate through lines, assigning them to sectors' linebuffers,
@@ -1952,11 +1960,14 @@ static void P_GroupLines(void)
 	{
 		M_ClearBox(bbox);
 
-		for (j = 0; j < sector->linecount; j++)
+		if (sector->linecount != 0)
 		{
-			li = sector->lines[j];
-			M_AddToBox(bbox, li->v1->x, li->v1->y);
-			M_AddToBox(bbox, li->v2->x, li->v2->y);
+			for (j = 0; j < sector->linecount; j++)
+			{
+				li = sector->lines[j];
+				M_AddToBox(bbox, li->v1->x, li->v1->y);
+				M_AddToBox(bbox, li->v2->x, li->v2->y);
+			}
 		}
 
 		// set the degenmobj_t to the middle of the bounding box

--- a/src/p_setup.c
+++ b/src/p_setup.c
@@ -1991,13 +1991,17 @@ static void P_LoadReject(lumpnum_t lumpnum)
 	if (!lumpname || memcmp(lumpname, "REJECT\0\0", 8) != 0)
 	{
 		rejectmatrix = NULL;
+		CONS_Debug(DBG_SETUP, "P_LoadReject: No valid REJECT lump found\n");
 		return;
 	}
 
 	count = W_LumpLength(lumpnum);
 
 	if (!count) // zero length, someone probably used ZDBSP
+	{
 		rejectmatrix = NULL;
+		CONS_Debug(DBG_SETUP, "P_LoadReject: REJECT lump has size 0, will not be loaded\n");
+	}
 	else
 		rejectmatrix = W_CacheLumpNum(lumpnum, PU_LEVEL);
 }

--- a/src/p_sight.c
+++ b/src/p_sight.c
@@ -325,9 +325,12 @@ boolean P_CheckSight(mobj_t *t1, mobj_t *t2)
 	s2 = t2->subsector->sector;
 	pnum = (s1-sectors)*numsectors + (s2-sectors);
 
-	// Check in REJECT table.
-	if (rejectmatrix[pnum>>3] & (1 << (pnum&7))) // can't possibly be connected
-		return false;
+	if (rejectmatrix != NULL)
+	{
+		// Check in REJECT table.
+		if (rejectmatrix[pnum>>3] & (1 << (pnum&7))) // can't possibly be connected
+			return false;
+	}
 
 	// killough 11/98: shortcut for melee situations
 	// same subsector? obviously visible


### PR DESCRIPTION
Changes made in this branch so far:
* a REJECT lump of zero length (NOT to be confused with a REJECT lump of non-zero length with all-zeros, just to clarify) should no longer cause problems with netgames and otherwise. The game now checks if the lump exists, has the right name, and length is not zero - if it fails any of these, the REJECT lump is not loaded and P_CheckSight won't be allowed to use it. This means ZDBSP (no reject) should be safe(r) to use now!
* there's now a simple devmode-only message (requires "Setup" mode) if a sector is found to have no lines at all during setup. It's a far cry from the plot to I_Error the game I once had for that unsusal scenario, but such a level still works anyway so whatever.