### PR TITLE
NAMEcLcR sprite angle loading

### DIFF
--- a/src/hardware/hw_main.c
+++ b/src/hardware/hw_main.c
@@ -5095,8 +5095,15 @@ static void HWR_ProjectSprite(mobj_t *thing)
 	if (sprframe->rotate)
 	{
 		// choose a different rotation based on player view
-		ang = R_PointToAngle(thing->x, thing->y); // uses viewx,viewy
-		rot = (ang-thing->angle+ANGLE_202h)>>29;
+		ang = R_PointToAngle (thing->x, thing->y) - thing->angle;
+
+		if ((ang < ANGLE_180) && (sprframe->rotate & 4)) // See from right
+			rot = 6; // F7 slot
+		else if ((ang >= ANGLE_180) && (sprframe->rotate & 2)) // See from left
+			rot = 2; // F3 slot
+		else // Normal behaviour
+			rot = (ang+ANGLE_202h)>>29;
+
 		//Fab: lumpid is the index for spritewidth,spriteoffset... tables
 		lumpoff = sprframe->lumpid[rot];
 		flip = sprframe->flip & (1<<rot);

--- a/src/hardware/hw_main.c
+++ b/src/hardware/hw_main.c
@@ -5092,14 +5092,21 @@ static void HWR_ProjectSprite(mobj_t *thing)
 		I_Error("sprframes NULL for sprite %d\n", thing->sprite);
 #endif
 
-	if (sprframe->rotate)
+	if (sprframe->rotate == SRF_SINGLE)
+	{
+		// use single rotation for all views
+		rot = 0;                        //Fab: for vis->patch below
+		lumpoff = sprframe->lumpid[0];     //Fab: see note above
+		flip = sprframe->flip; // Will only be 0x00 or 0xFF
+	}
+	else
 	{
 		// choose a different rotation based on player view
 		ang = R_PointToAngle (thing->x, thing->y) - thing->angle;
 
-		if ((ang < ANGLE_180) && (sprframe->rotate & 4)) // See from right
+		if ((ang < ANGLE_180) && (sprframe->rotate & SRF_RIGHT)) // See from right
 			rot = 6; // F7 slot
-		else if ((ang >= ANGLE_180) && (sprframe->rotate & 2)) // See from left
+		else if ((ang >= ANGLE_180) && (sprframe->rotate & SRF_LEFT)) // See from left
 			rot = 2; // F3 slot
 		else // Normal behaviour
 			rot = (ang+ANGLE_202h)>>29;
@@ -5107,13 +5114,6 @@ static void HWR_ProjectSprite(mobj_t *thing)
 		//Fab: lumpid is the index for spritewidth,spriteoffset... tables
 		lumpoff = sprframe->lumpid[rot];
 		flip = sprframe->flip & (1<<rot);
-	}
-	else
-	{
-		// use single rotation for all views
-		rot = 0;                        //Fab: for vis->patch below
-		lumpoff = sprframe->lumpid[0];     //Fab: see note above
-		flip = sprframe->flip; // Will only be 0x00 or 0xFF
 	}
 
 	if (thing->skin && ((skin_t *)thing->skin)->flags & SF_HIRES)

--- a/src/r_defs.h
+++ b/src/r_defs.h
@@ -729,11 +729,21 @@ typedef struct
 #pragma pack()
 #endif
 
+typedef enum
+{
+	SRF_SINGLE      = 0,   // 0-angle for all rotations
+	SRF_3D          = 1,   // Angles 1-8
+	SRF_LEFT        = 2,   // Left side has single patch
+	SRF_RIGHT       = 4,   // Right side has single patch
+	SRF_2D          = 6,   // SRF_LEFT|SRF_RIGHT
+	SRF_NONE        = 0xff // Initial value
+} spriterotateflags_t;     // SRF's up!
+
 //
 // Sprites are patches with a special naming convention so they can be
 //  recognized by R_InitSprites.
 // The base name is NNNNFx or NNNNFxFx, with x indicating the rotation,
-//  x = 0, 1-7.
+//  x = 0, 1-8, L/R
 // The sprite and frame specified by a thing_t is range checked at run time.
 // A sprite is a patch_t that is assumed to represent a three dimensional
 //  object and may have multiple rotations predrawn.
@@ -745,13 +755,9 @@ typedef struct
 //
 typedef struct
 {
-	// If false use 0 for any position.
-	// If L is present, (rotate & 2) == 2.
-	// If R is present, (rotate & 4) == 4.
-	// Otherwise, use 1.
 	// Note: as eight entries are available, we might as well insert the same
 	//  name eight times.
-	UINT8 rotate;
+	UINT8 rotate; // see spriterotateflags_t above
 
 	// Lump to use for view angles 0-7.
 	lumpnum_t lumppat[8]; // lump number 16 : 16 wad : lump

--- a/src/r_defs.h
+++ b/src/r_defs.h
@@ -739,10 +739,16 @@ typedef struct
 //  object and may have multiple rotations predrawn.
 // Horizontal flipping is used to save space, thus NNNNF2F5 defines a mirrored patch.
 // Some sprites will only have one picture used for all views: NNNNF0
+// Some sprites will take the entirety of the left side: NNNNFL
+// Or the right side: NNNNFR
+// Or both, mirrored: NNNNFLFR
 //
 typedef struct
 {
 	// If false use 0 for any position.
+	// If L is present, (rotate & 2) == 2.
+	// If R is present, (rotate & 4) == 4.
+	// Otherwise, use 1.
 	// Note: as eight entries are available, we might as well insert the same
 	//  name eight times.
 	UINT8 rotate;

--- a/src/r_things.c
+++ b/src/r_things.c
@@ -111,7 +111,7 @@ static void R_InstallSpriteLump(UINT16 wad,            // graphics patch
 		// the lump should be used for all rotations
 		if (sprtemp[frame].rotate == 0)
 			CONS_Debug(DBG_SETUP, "R_InitSprites: Sprite %s frame %c has multiple rot = 0 lump\n", spritename, cn);
-		else // Let's complain for both 1-8 and L/R rotations.
+		else if (sprtemp[frame].rotate != 0xff) // Let's complain for both 1-8 and L/R rotations.
 			CONS_Debug(DBG_SETUP, "R_InitSprites: Sprite %s frame %c has rotations and a rot = 0 lump\n", spritename, cn);
 
 		sprtemp[frame].rotate = 0;
@@ -154,15 +154,15 @@ static void R_InstallSpriteLump(UINT16 wad,            // graphics patch
 	else if (sprtemp[frame].rotate != 1)
 		CONS_Debug(DBG_SETUP, "R_InitSprites: Sprite %s frame %c has both L/R and 1-8 rotations\n", spritename, cn);
 
+	// make 0 based
+	rotation--;
+
 	if (rotation == 0 || rotation == 4) // Front or back...
 		sprtemp[frame].rotate = 1; // Prevent L and R changeover
 	else if (rotation > 3) // Right side
 		sprtemp[frame].rotate = (1 | (sprtemp[frame].rotate & 2)); // Continue allowing L frame changeover
 	else // if (rotation <= 3) // Left side
 		sprtemp[frame].rotate = (1 | (sprtemp[frame].rotate & 4)); // Continue allowing R frame changeover
-
-	// make 0 based
-	rotation--;
 
 	if (sprtemp[frame].lumppat[rotation] != LUMPERROR)
 		CONS_Debug(DBG_SETUP, "R_InitSprites: Sprite %s: %c%c has two lumps mapped to it\n", spritename, cn, '1'+rotation);

--- a/src/r_things.h
+++ b/src/r_things.h
@@ -17,6 +17,10 @@
 #include "sounds.h"
 #include "r_plane.h"
 
+// "Left" and "Right" character symbols for additional rotation functionality
+#define ROT_L ('L' - '0')
+#define ROT_R ('R' - '0')
+
 // number of sprite lumps for spritewidth,offset,topoffset lookup tables
 // Fab: this is a hack : should allocate the lookup tables per sprite
 #define MAXVISSPRITES 2048 // added 2-2-98 was 128
@@ -228,6 +232,11 @@ FUNCMATH FUNCINLINE static ATTRINLINE UINT8 R_Char2Frame(char cn)
 	if (cn == '@') return 63;
 	return 255;
 #endif
+}
+
+FUNCMATH FUNCINLINE static ATTRINLINE boolean R_ValidSpriteAngle(UINT8 rotation)
+{
+	return ((rotation <= 8) || (rotation == ROT_L) || (rotation == ROT_R));
 }
 
 #endif //__R_THINGS__


### PR DESCRIPTION
HEY LOOK, A NEW SPRITE LUMP LOADING FEATURE

* NAMEcL refers to a frame which is seen for the entirety of an object's left side. (ie - in 2d mode, facing to the left relative to the camera)
* NAMEcR refers to a name which is seen for the entirety of an object's right side. (ie - in 2d mode, facing to the right relative to the camera)
* NAMEcLcR does both sides, duh. I didn't break reflection.
* Having just a NAMEcL requires you to fill in the opposite side either with NAMEcn where n is 1 and 5-8 OR a NAMEcR OR a NAMEc0
* Having just a NAMEcR requires you to fill in the opposite side either with NAMEcn where n is 1-5 OR a NAMEcL OR a NAMEc0
* Switches down the centerline of the object instead of at the ANGLE_202h interval for normal sprites. Has a very small window where you can see a NAMEc1 and NAMEc5 if you only use one of NAMEcL or NAMEcR down one side.
* The specific symbols selected for this were selected for 1) ease of mental understanding (Left, Right) and 2) not getting in the way of adding support for zdoom's totally bananas 16-way sprite system at a later date if we so choose, which only goes up to G

totally makes sense for stuff like NiGHTS stuff, Axis2D stuff, and maybe if SRB1 survives the chopping block in some shape or form it can take advantage of that too

I could totally redo this for internal if needs must, but I figured it would be fun to have on Next since it's not a particularily intensive feature

~~~Test exe and file available at /toaster/srb2sprang.exe and /toaster/sprang.wad~~~