### PR TITLE
Skybox rendering offset fix for third person/alt view camera

### DIFF
--- a/src/r_main.c
+++ b/src/r_main.c
@@ -919,9 +919,9 @@ void R_SkyboxFrame(player_t *player)
 				}
 			}
 			if (mh->skybox_scalez > 0)
-				viewz += player->awayviewmobj->z / mh->skybox_scalez;
+				viewz += (player->awayviewmobj->z + 20*FRACUNIT) / mh->skybox_scalez;
 			else if (mh->skybox_scalez < 0)
-				viewz += player->awayviewmobj->z * -mh->skybox_scalez;
+				viewz += (player->awayviewmobj->z + 20*FRACUNIT) * -mh->skybox_scalez;
 		}
 		else if (thiscam->chase)
 		{
@@ -966,9 +966,9 @@ void R_SkyboxFrame(player_t *player)
 				}
 			}
 			if (mh->skybox_scalez > 0)
-				viewz += thiscam->z / mh->skybox_scalez;
+				viewz += (thiscam->z + (thiscam->height>>1)) / mh->skybox_scalez;
 			else if (mh->skybox_scalez < 0)
-				viewz += thiscam->z * -mh->skybox_scalez;
+				viewz += (thiscam->z + (thiscam->height>>1)) * -mh->skybox_scalez;
 		}
 		else
 		{


### PR DESCRIPTION
Fixes the issue reported in this thread: https://mb.srb2.org/showthread.php?t=41729

I dunno if this will negatively affect any existing skyboxes in SRB2's own levels, that said. I tried out THZ2 and CEZ1 with this fix at least but I forgot to compare them with how they are in 2.1.15 so _*shrugs_*