### PR TITLE
Fof slope crash fix

### DIFF
--- a/src/r_draw8.c
+++ b/src/r_draw8.c
@@ -1363,7 +1363,19 @@ void R_DrawColumnShadowed_8(void)
 
 		height = dc_lightlist[i].height >> LIGHTSCALESHIFT;
 		if (solid)
+		{
 			bheight = dc_lightlist[i].botheight >> LIGHTSCALESHIFT;
+			if (bheight < height)
+			{
+				// confounded slopes sometimes allow partial invertedness,
+				// even including cases where the top and bottom heights
+				// should actually be the same!
+				// swap the height values as a workaround for this quirk
+				INT32 temp = height;
+				height = bheight;
+				bheight = temp;
+			}
+		}
 		if (height <= dc_yl)
 		{
 			dc_colormap = dc_lightlist[i].rcolormap;


### PR DESCRIPTION
This fixes a case with sloped FOFs where "upside-down" parts of such FOFs (bottom higher than top I mean), or anything close enough to that like 0-height parts of such FOFs, crash the game in the software renderer.

Hopefully this stops FuriousFox's map crashing for the time being, all seemed fine when I tested it out myself.