### PR TITLE
P_FindSpecialLineFromTag crash fix

### DIFF
--- a/src/p_spec.c
+++ b/src/p_spec.c
@@ -1188,6 +1188,8 @@ INT32 P_FindSpecialLineFromTag(INT16 special, INT16 tag, INT32 start)
 	{
 		start++;
 
+		// This redundant check stops the compiler from complaining about function expansion
+		// elsewhere for some reason and everything is awful
 		if (start >= (INT32)numlines)
 			return -1;
 

--- a/src/p_spec.c
+++ b/src/p_spec.c
@@ -1188,7 +1188,10 @@ INT32 P_FindSpecialLineFromTag(INT16 special, INT16 tag, INT32 start)
 	{
 		start++;
 
-		while (lines[start].special != special)
+		if (start >= (INT32)numlines)
+			return -1;
+
+		while (start < (INT32)numlines && lines[start].special != special)
 			start++;
 
 		if (start >= (INT32)numlines)


### PR DESCRIPTION
This fixes the case where an in-level sector or FOF control sector with a tag of -1 or 65535 (seriously, who does that?) can possibly lead to a crash in this function when searching for heat linedef specials in 1st person. And also the same kind of crash any other sort of weird case where the tag number that function uses for searching is -1 or 65535, I suppose!