### PR TITLE
-warp checking for invalid map names

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1060,10 +1060,11 @@ void D_SRB2Main(void)
 	if (M_CheckParm("-warp") && M_IsNextParm())
 	{
 		const char *word = M_GetNextParm();
-		if (fastncmp(word, "MAP", 3))
+		char ch; // use this with sscanf to catch non-digits with
+		if (fastncmp(word, "MAP", 3)) // MAPxx name
 			pstartmap = M_MapNumber(word[3], word[4]);
-		else
-			pstartmap = atoi(word);
+		else if (sscanf(word, "%d%c", &pstartmap, &ch) != 1) // a plain number
+			I_Error("Cannot warp to map %s (invalid map name)\n", word);
 		// Don't check if lump exists just yet because the wads haven't been loaded!
 		// Just do a basic range check here.
 		if (pstartmap < 1 || pstartmap > NUMMAPS)


### PR DESCRIPTION
I've noticed a bunch of new people getting the "Cannot warp to map 0 (out of range)" error when testing their custom maps. On asking what map name they used, it was clear they didn't use a MAPxx name at all. Sadly it was not obvious to them that other kind of map names are not accepted by SRB2, so I thought it best we make that more clear in-game.

SRB2 now gives you the error "Cannot warp to map \[your input\] (invalid map name)" if you used -warp with a param that is neither a MAPxx name or a plain number.