### PR TITLE
Last-minute NiGHTS exiting bugfix

### DIFF
--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -6931,6 +6931,7 @@ void P_MobjThinker(mobj_t *mobj)
 					{
 						mobj->flags &= ~MF_NOGRAVITY;
 						P_SetMobjState(mobj, S_NIGHTSDRONE1);
+						mobj->flags2 |= MF2_DONTDRAW;
 					}
 				}
 				else if (mobj->tracer && mobj->tracer->player)

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -974,8 +974,8 @@ static void ST_drawNiGHTSHUD(void)
 	if (cv_debug & DBG_NIGHTSBASIC)
 		minlink = 0;
 
-	// Cheap hack: don't display when the score is showing or you're exiting a map
-	if ((stplyr->exiting) || (stplyr->texttimer && stplyr->textvar == 4))
+	// Cheap hack: don't display when the score is showing (it popping up for a split second when exiting a map is intentional)
+	if (stplyr->texttimer && stplyr->textvar == 4)
 		minlink = INT32_MAX;
 
 	if (G_IsSpecialStage(gamemap))

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -974,8 +974,8 @@ static void ST_drawNiGHTSHUD(void)
 	if (cv_debug & DBG_NIGHTSBASIC)
 		minlink = 0;
 
-	// Cheap hack: don't display when the score is showing
-	if (stplyr->texttimer && stplyr->textvar == 4)
+	// Cheap hack: don't display when the score is showing or you're exiting a map
+	if ((stplyr->exiting) || (stplyr->texttimer && stplyr->textvar == 4))
 		minlink = INT32_MAX;
 
 	if (G_IsSpecialStage(gamemap))


### PR DESCRIPTION
One single-line fix concerning the end of NiGHTS maps. Extremely small, literally zero side effects here, the only reason I'm not committing directly to master (aside from ettiquette) is that I don't have the ability to do so.

* The NiGHTS drone had a single tic of visibility when you hit the goal, which is evident stepping frame by frame through http://gfycat.com/ComplicatedComposedAoudad (the contents of which may or may not make it into 2.2). This is no longer the case.