### PR TITLE
Climbing shit 2 electric boogaloo: an adventure in how much toast hates how the ogl renderer was implemented

### DIFF
--- a/src/p_map.c
+++ b/src/p_map.c
@@ -2657,7 +2657,7 @@ isblocking:
 		// see about climbing on the wall
 		if (!(checkline->flags & ML_NOCLIMB))
 		{
-			boolean canclimb; // FUCK C90
+			boolean canclimb;
 			angle_t climbangle, climbline;
 			INT32 whichside = P_PointOnLineSide(slidemo->x, slidemo->y, li);
 

--- a/src/p_user.c
+++ b/src/p_user.c
@@ -2276,25 +2276,24 @@ static void P_DoClimbing(player_t *player)
 	fixed_t platy;
 	subsector_t *glidesector;
 	boolean climb = true;
+	boolean onesided = ((player->lastsidehit != -1 && player->lastlinehit != -1) && !(lines[player->lastlinehit].backsector));
 
 	platx = P_ReturnThrustX(player->mo, player->mo->angle, player->mo->radius + FixedMul(8*FRACUNIT, player->mo->scale));
 	platy = P_ReturnThrustY(player->mo, player->mo->angle, player->mo->radius + FixedMul(8*FRACUNIT, player->mo->scale));
 
-	glidesector = R_IsPointInSubsector(player->mo->x + platx, player->mo->y + platy);
+	glidesector = R_PointInSubsector(player->mo->x + platx, player->mo->y + platy);
 
-	if (!glidesector || glidesector->sector != player->mo->subsector->sector)
+	if (onesided || glidesector->sector != player->mo->subsector->sector)
 	{
-		boolean floorclimb;
-		boolean thrust;
-		boolean boostup;
-		boolean skyclimber;
+		boolean floorclimb = false;
+		boolean thrust = false;
+		boolean boostup = false;
+		boolean skyclimber = false;
 		fixed_t floorheight, ceilingheight; // ESLOPE
-		thrust = false;
-		floorclimb = false;
-		boostup = false;
-		skyclimber = false;
 
-		if (glidesector)
+		if (onesided)
+			floorclimb = true;
+		else
 		{
 #ifdef ESLOPE
 			floorheight = glidesector->sector->f_slope ? P_GetZAt(glidesector->sector->f_slope, player->mo->x, player->mo->y)
@@ -2589,8 +2588,6 @@ static void P_DoClimbing(player_t *player)
 				}
 			}
 		}
-		else
-			floorclimb = true;
 
 		if (player->lastsidehit != -1 && player->lastlinehit != -1)
 		{

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -33,6 +33,7 @@
 
 #ifdef HWRENDER
 #include "hardware/hw_main.h"
+#include "hardware/hw_glob.h" // polyvertex_t
 #endif
 
 //profile stuff ---------------------------------------------------------
@@ -268,10 +269,28 @@ INT32 R_PointOnSide(fixed_t x, fixed_t y, node_t *node)
 // killough 5/2/98: reformatted
 INT32 R_PointOnSegSide(fixed_t x, fixed_t y, seg_t *line)
 {
-	fixed_t lx = line->v1->x;
-	fixed_t ly = line->v1->y;
-	fixed_t ldx = line->v2->x - lx;
-	fixed_t ldy = line->v2->y - ly;
+	fixed_t lx, ly, ldx, ldy;
+
+#ifdef HWRENDER // how did nobody notice this for years
+	// used for the hardware render
+	if (rendermode != render_soft && rendermode != render_none)
+	{
+		lx = FLOAT_TO_FIXED(((polyvertex_t *)line->v1)->x);
+		ly = FLOAT_TO_FIXED(((polyvertex_t *)line->v1)->y);
+		ldx = FLOAT_TO_FIXED(((polyvertex_t *)line->v2)->x);
+		ldy = FLOAT_TO_FIXED(((polyvertex_t *)line->v2)->y);
+	}
+	else
+#endif
+	{
+		lx = line->v1->x;
+		ly = line->v1->y;
+		ldx = line->v2->x;
+		ldy = line->v2->y;
+	}
+
+	ldx -= lx;
+	ldy -= ly;
 
 	if (!ldx)
 		return x <= lx ? ldy > 0 : ldy < 0;

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -771,7 +771,7 @@ subsector_t *R_PointInSubsector(fixed_t x, fixed_t y)
 }
 
 //
-// R_IsPointInSubsector, same as above but returns 0 if not in subsector
+// R_IsPointInSubsector, same as above but returns 0 if not in subsector - this does not work in opengl because of polyvertex_t
 //
 subsector_t *R_IsPointInSubsector(fixed_t x, fixed_t y)
 {

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -33,7 +33,6 @@
 
 #ifdef HWRENDER
 #include "hardware/hw_main.h"
-#include "hardware/hw_glob.h" // polyvertex_t
 #endif
 
 //profile stuff ---------------------------------------------------------
@@ -269,28 +268,10 @@ INT32 R_PointOnSide(fixed_t x, fixed_t y, node_t *node)
 // killough 5/2/98: reformatted
 INT32 R_PointOnSegSide(fixed_t x, fixed_t y, seg_t *line)
 {
-	fixed_t lx, ly, ldx, ldy;
-
-#ifdef HWRENDER // how did nobody notice this for years
-	// used for the hardware render
-	if (rendermode != render_soft && rendermode != render_none)
-	{
-		lx = FLOAT_TO_FIXED(((polyvertex_t *)line->v1)->x);
-		ly = FLOAT_TO_FIXED(((polyvertex_t *)line->v1)->y);
-		ldx = FLOAT_TO_FIXED(((polyvertex_t *)line->v2)->x);
-		ldy = FLOAT_TO_FIXED(((polyvertex_t *)line->v2)->y);
-	}
-	else
-#endif
-	{
-		lx = line->v1->x;
-		ly = line->v1->y;
-		ldx = line->v2->x;
-		ldy = line->v2->y;
-	}
-
-	ldx -= lx;
-	ldy -= ly;
+	fixed_t lx = line->v1->x;
+	fixed_t ly = line->v1->y;
+	fixed_t ldx = line->v2->x - lx;
+	fixed_t ldy = line->v2->y - ly;
 
 	if (!ldx)
 		return x <= lx ? ldy > 0 : ldy < 0;


### PR DESCRIPTION
Fixed Knuckles being able to climb in space in OpenGL. 

To understand: look at AjustSegs(void) in hw_bsp.c. It reallocates the vetex_t pointers for lines as POLYVERTEX_T pointers, and of COURSE things are gonna get wacky when you're casting pointers.

I dunno how resilient the FLOAT_TO_FIXED solution is or whether it'll be netgame compatible (yayyy float precision loss) but it's not like our builds are netgame compatible with themselves

This merge request is into master because it's a bug that's IN master and must never reach the public because of how bad it is