### PR TITLE
Allowing the disabling of Match/CTF/Miscellaneous Ringslinger HUD elements 

### DIFF
--- a/src/lua_hud.h
+++ b/src/lua_hud.h
@@ -18,6 +18,9 @@ enum hud {
 	hud_time,
 	hud_rings,
 	hud_lives,
+	// Match
+	hud_weaponrings,
+	hud_powerstones,
 	// NiGHTS mode
 	hud_nightslink,
 	hud_nightsdrill,

--- a/src/lua_hud.h
+++ b/src/lua_hud.h
@@ -18,7 +18,7 @@ enum hud {
 	hud_time,
 	hud_rings,
 	hud_lives,
-	// Match
+	// Match / CTF / Tag / Ringslinger
 	hud_weaponrings,
 	hud_powerstones,
 	// NiGHTS mode

--- a/src/lua_hudlib.c
+++ b/src/lua_hudlib.c
@@ -44,6 +44,9 @@ static const char *const hud_disable_options[] = {
 	"rings",
 	"lives",
 
+	"weaponrings",
+	"powerstones",
+
 	"nightslink",
 	"nightsdrill",
 	"nightsrings",

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -1385,6 +1385,10 @@ static void ST_drawMatchHUD(void)
 	if (G_TagGametype() && !(stplyr->pflags & PF_TAGIT))
 		return;
 
+#ifdef HAVE_BLUA
+	if (LUA_HudEnabled(hud_weaponrings)) {
+#endif
+
 	if (stplyr->powers[pw_infinityring])
 		ST_drawWeaponRing(pw_infinityring, 0, 0, offset, infinityring);
 	else if (stplyr->health > 1)
@@ -1407,6 +1411,12 @@ static void ST_drawMatchHUD(void)
 	ST_drawWeaponRing(pw_explosionring, RW_EXPLODE, WEP_EXPLODE, offset, explosionring);
 	offset += 20;
 	ST_drawWeaponRing(pw_railring, RW_RAIL, WEP_RAIL, offset, railring);
+
+#ifdef HAVE_BLUA
+	}
+
+	if (LUA_HudEnabled(hud_powerstones)) {
+#endif
 
 	// Power Stones collected
 	offset = 136; // Used for Y now
@@ -1439,6 +1449,10 @@ static void ST_drawMatchHUD(void)
 
 	if (stplyr->powers[pw_emeralds] & EMERALD7)
 		V_DrawScaledPatch(28, STRINGY(offset), V_SNAPTOLEFT, tinyemeraldpics[6]);
+
+#ifdef HAVE_BLUA
+	}
+#endif
 }
 
 static inline void ST_drawRaceHUD(void)


### PR DESCRIPTION
Does what it says on the tin.

Requested by Lat and Speedwagon, selfishly also desired because of Thokker, open and shut. If 2.1.16 is delayed, might as well get some goodwill-raising zero-effort stuff in there.