### PR TITLE
Cutscene switch fix

### DIFF
--- a/src/f_finale.c
+++ b/src/f_finale.c
@@ -1725,6 +1725,7 @@ static void F_AdvanceToNextScene(void)
 
 void F_EndCutScene(void)
 {
+	cutsceneover = true; // do this first, just in case Y_EndGame or something wants to turn it back false later
 	if (runningprecutscene)
 	{
 		if (server)
@@ -1741,7 +1742,6 @@ void F_EndCutScene(void)
 		else
 			Y_EndGame();
 	}
-	cutsceneover = true;
 }
 
 void F_StartCustomCutscene(INT32 cutscenenum, boolean precutscene, boolean resetplayer)


### PR DESCRIPTION
Yet another fix for SUGOI, lol: apparently going from a final level's post-cutscene straight to a custom credits cutscene gets the latter stuck forever in the first scene (because the game accidentally stops the cutscene responder from realising the custom credits cutscene is running). This branch of course makes a fix for that.