### PR TITLE
Fix demo recording in Linux

### DIFF
--- a/src/g_game.c
+++ b/src/g_game.c
@@ -5529,6 +5529,7 @@ void G_StopDemo(void)
 boolean G_CheckDemoStatus(void)
 {
 	boolean saved;
+	char fulldemoname[128]; //Demo name with srb2home path
 
 	if(ghosts) // ... ... ...
 		ghosts = NULL; // :)
@@ -5580,7 +5581,6 @@ boolean G_CheckDemoStatus(void)
 		md5_buffer((char *)p+16, demo_p - (p+16), p); // make a checksum of everything after the checksum in the file.
 #endif
 
-		char fulldemoname [128];
 		sprintf(fulldemoname, "%s"PATHSEP"%s", srb2home, demoname);
 		saved = FIL_WriteFile(fulldemoname, demobuffer, demo_p - demobuffer); // finally output the file.
 		free(demobuffer);

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -5529,7 +5529,6 @@ void G_StopDemo(void)
 boolean G_CheckDemoStatus(void)
 {
 	boolean saved;
-	char fulldemoname[128]; //Demo name with srb2home path
 
 	if(ghosts) // ... ... ...
 		ghosts = NULL; // :)
@@ -5580,9 +5579,7 @@ boolean G_CheckDemoStatus(void)
 		WRITEUINT8(demo_p, DEMOMARKER); // add the demo end marker
 		md5_buffer((char *)p+16, demo_p - (p+16), p); // make a checksum of everything after the checksum in the file.
 #endif
-
-		sprintf(fulldemoname, "%s"PATHSEP"%s", srb2home, demoname);
-		saved = FIL_WriteFile(fulldemoname, demobuffer, demo_p - demobuffer); // finally output the file.
+		saved = FIL_WriteFile(va(pandf, srb2home, demoname), demobuffer, demo_p - demobuffer); // finally output the file.
 		free(demobuffer);
 		demorecording = false;
 

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -5579,7 +5579,10 @@ boolean G_CheckDemoStatus(void)
 		WRITEUINT8(demo_p, DEMOMARKER); // add the demo end marker
 		md5_buffer((char *)p+16, demo_p - (p+16), p); // make a checksum of everything after the checksum in the file.
 #endif
-		saved = FIL_WriteFile(demoname, demobuffer, demo_p - demobuffer); // finally output the file.
+
+		char fulldemoname [128];
+		sprintf(fulldemoname, "%s"PATHSEP"%s", srb2home, demoname);
+		saved = FIL_WriteFile(fulldemoname, demobuffer, demo_p - demobuffer); // finally output the file.
 		free(demobuffer);
 		demorecording = false;
 


### PR DESCRIPTION
As reported: http://mb.srb2.org/showthread.php?t=38792

Turns out srb2 attempts to record demos to replay/main/[demoname].lmp, but expects demo files to be in [srb2home]/replay/main/[demoname].lmp.  Note the use of a relative path.  With Linux, if [srb2home] and the binary directory aren't the same, then demos won't be written, and if you make replay/main, then they will but SRB2 won't be able to locate them.

This fix ensures that demos are actually saved to [srb2home].  This should change nothing on Windows and fix everything on Linux.  There's also a chance it'll fix OS X.  But do note, I'm too lazy to test on Windows and I don't have access to an OS X machine to test that.