### PR TITLE
Prevent resampling-related crashes on Linux 64-bit

### DIFF
--- a/src/sdl/mixer_sound.c
+++ b/src/sdl/mixer_sound.c
@@ -220,7 +220,7 @@ static Mix_Chunk *ds2chunk(void *stream)
 		break;
 	default: // convert arbitrary hz to 44100.
 		step = 0;
-		frac = ((UINT32)freq << FRACBITS) / 44100;
+		frac = ((UINT32)freq << FRACBITS) / 44100 + 1; //Add 1 to counter truncation.
 		while (i < samples)
 		{
 			o = (INT16)(*s+0x80)<<8; // changed signedness and shift up to 16 bits


### PR DESCRIPTION
Due to the way SRB2 resamples sounds, the result of a division is stored into an integer value, resulting in truncation.   The truncated value, frac is something like a percent counter, counting the percent of sound samples that have played in a range.  When there are more samples than the native output rate of 44100, this truncation causes all sound samples to have played prior to the counter reaching full, and the game will attempt to play non-allocated memory, resulting in a crash.  Why this crash isn't apparent in 32-bit, I have no idea.  It may have to do with how memory is internally managed.

The fix in this pull request probably isn't "correct," but it's as correct as the last time I fixed a sound crash, which is just above in line 176.