### PR TITLE
Even more slope-related fixes

### DIFF
--- a/src/p_spec.c
+++ b/src/p_spec.c
@@ -7428,7 +7428,7 @@ void T_Pusher(pusher_t *p)
 			}
 			else
 			{
-				if (top < thing->z || referrer->floorheight > (thing->z + (thing->height >> 1)))
+				if (top < thing->z || bottom > (thing->z + (thing->height >> 1)))
 					continue;
 				if (thing->z + thing->height > top)
 					touching = true;


### PR DESCRIPTION
What it says on the tin pretty much:

Currently included fixes:
* Pusher specials applied to FOFs did not properly account for slopes applied to the bottom plane; this probably was just a minor slipup that appeared on adding the support in the first place, I take it? (some waterfall in the last section of SUGOI's Fudge Canyon is the only place I can think of offhand where this bug is noticable)