### PR TITLE
Fix for vid_copy.s crash in Fudge Canyon

### DIFF
--- a/src/r_plane.c
+++ b/src/r_plane.c
@@ -402,6 +402,15 @@ void R_ClearPlanes(void)
 	// scale will be unit scale at SCREENWIDTH/2 distance
 	basexscale = FixedDiv (FINECOSINE(angle),centerxfrac);
 	baseyscale = -FixedDiv (FINESINE(angle),centerxfrac);
+
+#ifdef POLYOBJECTS_PLANES
+	// clear all old visplanes pointers away, in case they're still there (fixes vid_copy.s crash)
+	if (numPolyObjects)
+	{
+		for (i = 0; i < numPolyObjects; i++)
+			PolyObjects[i].visplane = NULL;
+	}
+#endif
 }
 
 static visplane_t *new_visplane(unsigned hash)


### PR DESCRIPTION
What it says on the tin. (Fudge Canyon is a level in SUGOI, for those not aware) I think this was ultimately some problem with clearing away outdated polyobject visplane pointers. (the commit description explains how the crash comes about and how I think my explanation causes it, more or less)

I most often got this crash myself around the area with the exploding chocolate "polybars", particularly when standing on the floor around the highest of the three starting points of them. Though it is hard to reproduce the crash, and having tested this fix for myself I have not encountered the crash again (yet). If others could test this fix to ensure it has indeed been fixed, that would be very helpful.
