### PR TITLE
Fixing various problems with MF_SOLID collision

### DIFF
--- a/src/p_map.c
+++ b/src/p_map.c
@@ -994,7 +994,7 @@ static boolean PIT_CheckThing(mobj_t *thing)
 			if (tmthing->player && tmthing->z + tmthing->height > topz
 				&& tmthing->z + tmthing->height < tmthing->ceilingz)
 			{
-				tmceilingz = INT32_MIN; // block while in air
+				tmfloorz = tmceilingz = INT32_MIN; // block while in air
 #ifdef ESLOPE
 				tmceilingslope = NULL;
 #endif
@@ -1037,7 +1037,7 @@ static boolean PIT_CheckThing(mobj_t *thing)
 			if (tmthing->player && tmthing->z < topz
 				&& tmthing->z > tmthing->floorz)
 			{
-				tmfloorz = INT32_MAX; // block while in air
+				tmfloorz = tmceilingz = INT32_MAX; // block while in air
 #ifdef ESLOPE
 				tmfloorslope = NULL;
 #endif

--- a/src/p_map.c
+++ b/src/p_map.c
@@ -985,7 +985,7 @@ static boolean PIT_CheckThing(mobj_t *thing)
 				return true;
 			}
 
-			topz = thing->z - thing->scale;
+			topz = thing->z - thing->scale; // FixedMul(FRACUNIT, thing->scale), but thing->scale == FRACUNIT in base scale anyways
 
 			// block only when jumping not high enough,
 			// (dont climb max. 24units while already in air)
@@ -1028,7 +1028,7 @@ static boolean PIT_CheckThing(mobj_t *thing)
 				return true;
 			}
 
-			topz = thing->z + thing->height + thing->scale;
+			topz = thing->z + thing->height + thing->scale; // FixedMul(FRACUNIT, thing->scale), but thing->scale == FRACUNIT in base scale anyways
 
 			// block only when jumping not high enough,
 			// (dont climb max. 24units while already in air)

--- a/src/p_map.c
+++ b/src/p_map.c
@@ -989,12 +989,18 @@ static boolean PIT_CheckThing(mobj_t *thing)
 
 			// block only when jumping not high enough,
 			// (dont climb max. 24units while already in air)
-			// if not in air, let P_TryMove() decide if it's not too high
+			// since return false doesn't handle momentum properly,
+			// we lie to P_TryMove() so it's always too high
 			if (tmthing->player && tmthing->z + tmthing->height > topz
 				&& tmthing->z + tmthing->height < tmthing->ceilingz)
-				return false; // block while in air
-
-			if (thing->flags & MF_SPRING)
+			{
+				tmceilingz = INT32_MIN; // block while in air
+#ifdef ESLOPE
+				tmceilingslope = NULL;
+#endif
+				tmfloorthing = thing; // needed for side collision
+			}
+			else if (thing->flags & MF_SPRING)
 				;
 			else if (topz < tmceilingz && tmthing->z <= thing->z+thing->height)
 			{
@@ -1026,11 +1032,18 @@ static boolean PIT_CheckThing(mobj_t *thing)
 
 			// block only when jumping not high enough,
 			// (dont climb max. 24units while already in air)
-			// if not in air, let P_TryMove() decide if it's not too high
-			if (tmthing->player && tmthing->z < topz && tmthing->z > tmthing->floorz)
-				return false; // block while in air
-
-			if (thing->flags & MF_SPRING)
+			// since return false doesn't handle momentum properly,
+			// we lie to P_TryMove() so it's always too high
+			if (tmthing->player && tmthing->z < topz
+				&& tmthing->z > tmthing->floorz)
+			{
+				tmfloorz = INT32_MAX; // block while in air
+#ifdef ESLOPE
+				tmfloorslope = NULL;
+#endif
+				tmfloorthing = thing; // needed for side collision
+			}
+			else if (thing->flags & MF_SPRING)
 				;
 			else if (topz > tmfloorz && tmthing->z+tmthing->height >= thing->z)
 			{

--- a/src/p_map.c
+++ b/src/p_map.c
@@ -985,7 +985,7 @@ static boolean PIT_CheckThing(mobj_t *thing)
 				return true;
 			}
 
-			topz = thing->z - FixedMul(FRACUNIT, thing->scale);
+			topz = thing->z - thing->scale;
 
 			// block only when jumping not high enough,
 			// (dont climb max. 24units while already in air)
@@ -996,7 +996,7 @@ static boolean PIT_CheckThing(mobj_t *thing)
 
 			if (thing->flags & MF_SPRING)
 				;
-			else if (topz < tmceilingz && tmthing->z+tmthing->height <= thing->z+thing->height)
+			else if (topz < tmceilingz && tmthing->z <= thing->z+thing->height)
 			{
 				tmceilingz = topz;
 #ifdef ESLOPE
@@ -1022,7 +1022,7 @@ static boolean PIT_CheckThing(mobj_t *thing)
 				return true;
 			}
 
-			topz = thing->z + thing->height + FixedMul(FRACUNIT, thing->scale);
+			topz = thing->z + thing->height + thing->scale;
 
 			// block only when jumping not high enough,
 			// (dont climb max. 24units while already in air)
@@ -1032,7 +1032,7 @@ static boolean PIT_CheckThing(mobj_t *thing)
 
 			if (thing->flags & MF_SPRING)
 				;
-			else if (topz > tmfloorz && tmthing->z >= thing->z)
+			else if (topz > tmfloorz && tmthing->z+tmthing->height >= thing->z)
 			{
 				tmfloorz = topz;
 #ifdef ESLOPE


### PR DESCRIPTION
* Solid objects are now no longer intangible when your z is less than the other object's.
    * I originally thought the bug was limited to just solid objects on slopes (hence the branch name), and was wondering about undesired side effects - but looking at this gfy, this was a major bug that slopes made easier to expose.
    * Unfixed = http://gfycat.com/BareLimitedCavy
    * Fixed = http://gfycat.com/JubilantOffensiveGar
* You now properly lose your momentum when jumping at a solid object.
    * The way I fixed this was a hack, but it was originally a much worse hack which resulted in very bizzare physics issues, so...
    * Unfixed = http://gfycat.com/ShockingAbsoluteArthropods (also demonstrates the first bug)
    * Fixed = http://gfycat.com/EmbellishedCourageousGordonsetter