### PR TITLE
Fixed players disappearing when spindashing whilst wearing multi-layer shields 

### DIFF
--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -5930,6 +5930,8 @@ static boolean P_ShieldLook(mobj_t *thing, shieldtype_t shield)
 	P_UnsetThingPosition(thing);
 	thing->x = thing->target->x;
 	thing->y = thing->target->y;
+	thing->radius = thing->target->radius;
+	thing->height = thing->target->height;
 	if (thing->eflags & MFE_VERTICALFLIP)
 		thing->z = thing->target->z + thing->target->height - thing->height + FixedDiv(P_GetPlayerHeight(thing->target->player) - thing->target->height, 3*FRACUNIT) - FixedMul(2*FRACUNIT, thing->target->scale);
 	else
@@ -6048,6 +6050,8 @@ void P_RunOverlays(void)
 		P_UnsetThingPosition(mo);
 		mo->x = destx;
 		mo->y = desty;
+		mo->radius = mo->target->radius;
+		mo->height = mo->target->height;
 		if (mo->eflags & MFE_VERTICALFLIP)
 			mo->z = (mo->target->z + mo->target->height - mo->height) - zoffs;
 		else


### PR DESCRIPTION
* Before: http://i.imgur.com/gxUFElo.png
* After: http://i.imgur.com/NxsOg94.png

The problem was that MT_OVERLAY's default radius and height were never getting changed from 1*FRACUNIT, and that meant that when you spindashed, the game considered it completely below the surface of the flat you were standing on. Since you're not usually clipped on flats that don't belong to FOFs, we didn't notice this aspect of the issue sooner.

I'm also tweaking the shield stuff to make SURE it doesn't happen again, but I doubt it's strictly necessary.