### PR TITLE
v.drawScaled negative scales fix

### DIFF
--- a/src/lua_hudlib.c
+++ b/src/lua_hudlib.c
@@ -369,6 +369,8 @@ static int libd_drawScaled(lua_State *L)
 	x = luaL_checkinteger(L, 1);
 	y = luaL_checkinteger(L, 2);
 	scale = luaL_checkinteger(L, 3);
+	if (scale < 0)
+		return luaL_error(L, "negative scale");
 	patch = *((patch_t **)luaL_checkudata(L, 4, META_PATCH));
 	flags = luaL_optinteger(L, 5, 0);
 	if (!lua_isnoneornil(L, 6))


### PR DESCRIPTION
Lua now errors if you try to use negative scales with v.drawScaled, rather than crashing as it does in 2.1.16 currently. Not much else to say here.