### PR TITLE
Software plane rendering fixes/cleanup

### DIFF
--- a/src/r_bsp.c
+++ b/src/r_bsp.c
@@ -925,6 +925,9 @@ static void R_Subsector(size_t num)
 	{
 		floorplane = R_FindPlane(frontsector->floorheight, frontsector->floorpic, floorlightlevel,
 			frontsector->floor_xoffs, frontsector->floor_yoffs, frontsector->floorpic_angle, floorcolormap, NULL
+#ifdef POLYOBJECTS_PLANES
+			, NULL
+#endif
 #ifdef ESLOPE
 			, frontsector->f_slope
 #endif
@@ -944,6 +947,9 @@ static void R_Subsector(size_t num)
 		ceilingplane = R_FindPlane(frontsector->ceilingheight, frontsector->ceilingpic,
 			ceilinglightlevel, frontsector->ceiling_xoffs, frontsector->ceiling_yoffs, frontsector->ceilingpic_angle,
 			ceilingcolormap, NULL
+#ifdef POLYOBJECTS_PLANES
+			, NULL
+#endif
 #ifdef ESLOPE
 			, frontsector->c_slope
 #endif
@@ -1002,6 +1008,9 @@ static void R_Subsector(size_t num)
 				ffloor[numffloors].plane = R_FindPlane(*rover->bottomheight, *rover->bottompic,
 					*frontsector->lightlist[light].lightlevel, *rover->bottomxoffs,
 					*rover->bottomyoffs, *rover->bottomangle, frontsector->lightlist[light].extra_colormap, rover
+#ifdef POLYOBJECTS_PLANES
+					, NULL
+#endif
 #ifdef ESLOPE
 					, *rover->b_slope
 #endif
@@ -1045,6 +1054,9 @@ static void R_Subsector(size_t num)
 				ffloor[numffloors].plane = R_FindPlane(*rover->topheight, *rover->toppic,
 					*frontsector->lightlist[light].lightlevel, *rover->topxoffs, *rover->topyoffs, *rover->topangle,
 					frontsector->lightlist[light].extra_colormap, rover
+#ifdef POLYOBJECTS_PLANES
+					, NULL
+#endif
 #ifdef ESLOPE
 					, *rover->t_slope
 #endif
@@ -1111,11 +1123,13 @@ static void R_Subsector(size_t num)
 						polysec->floorpic_angle-po->angle,
 						NULL,
 						NULL
+#ifdef POLYOBJECTS_PLANES
+					, po
+#endif
 #ifdef ESLOPE
 					, NULL // will ffloors be slopable eventually?
 #endif
 					);
-				//ffloor[numffloors].plane->polyobj = po;
 
 				ffloor[numffloors].height = polysec->floorheight;
 				ffloor[numffloors].polyobj = po;
@@ -1155,11 +1169,13 @@ static void R_Subsector(size_t num)
 				ffloor[numffloors].plane = R_FindPlane(polysec->ceilingheight, polysec->ceilingpic,
 					polysec->lightlevel, xoff, yoff, polysec->ceilingpic_angle-po->angle,
 					NULL, NULL
+#ifdef POLYOBJECTS_PLANES
+					, po
+#endif
 #ifdef ESLOPE
 					, NULL // will ffloors be slopable eventually?
 #endif
 					);
-				//ffloor[numffloors].plane->polyobj = po;
 
 				ffloor[numffloors].polyobj = po;
 				ffloor[numffloors].height = polysec->ceilingheight;

--- a/src/r_plane.c
+++ b/src/r_plane.c
@@ -431,6 +431,9 @@ static visplane_t *new_visplane(unsigned hash)
 visplane_t *R_FindPlane(fixed_t height, INT32 picnum, INT32 lightlevel,
 	fixed_t xoff, fixed_t yoff, angle_t plangle, extracolormap_t *planecolormap,
 	ffloor_t *pfloor
+#ifdef POLYOBJECTS_PLANES
+			, polyobj_t *polyobj
+#endif
 #ifdef ESLOPE
 			, pslope_t *slope
 #endif
@@ -470,6 +473,8 @@ visplane_t *R_FindPlane(fixed_t height, INT32 picnum, INT32 lightlevel,
 #ifdef POLYOBJECTS_PLANES
 		if (check->polyobj && pfloor)
 			continue;
+		if (polyobj != check->polyobj)
+			continue;
 #endif
 		if (height == check->height && picnum == check->picnum
 			&& lightlevel == check->lightlevel
@@ -504,7 +509,7 @@ visplane_t *R_FindPlane(fixed_t height, INT32 picnum, INT32 lightlevel,
 	check->viewangle = viewangle;
 	check->plangle = plangle;
 #ifdef POLYOBJECTS_PLANES
-	check->polyobj = NULL;
+	check->polyobj = polyobj;
 #endif
 #ifdef ESLOPE
 	check->slope = slope;
@@ -719,7 +724,11 @@ void R_DrawPlanes(void)
 				continue;
 			}
 
-			if (pl->ffloor != NULL)
+			if (pl->ffloor != NULL
+#ifdef POLYOBJECTS_PLANES
+			|| pl->polyobj != NULL
+#endif
+			)
 				continue;
 
 			R_DrawSinglePlane(pl);

--- a/src/r_plane.h
+++ b/src/r_plane.h
@@ -97,6 +97,9 @@ void R_MakeSpans(INT32 x, INT32 t1, INT32 b1, INT32 t2, INT32 b2);
 void R_DrawPlanes(void);
 visplane_t *R_FindPlane(fixed_t height, INT32 picnum, INT32 lightlevel, fixed_t xoff, fixed_t yoff, angle_t plangle,
 	extracolormap_t *planecolormap, ffloor_t *ffloor
+#ifdef POLYOBJECTS_PLANES
+	, polyobj_t *polyobj
+#endif
 #ifdef ESLOPE
 	, pslope_t *slope
 #endif

--- a/src/r_things.c
+++ b/src/r_things.c
@@ -1699,21 +1699,25 @@ static void R_CreateDrawNodes(void)
 				entry->ffloor = ds->thicksides[i];
 			}
 		}
+#ifdef POLYOBJECTS_PLANES
+		// Check for a polyobject plane, but only if this is a front line
+		if (ds->curline->polyseg && ds->curline->polyseg->visplane && !ds->curline->side) {
+			plane = ds->curline->polyseg->visplane;
+			R_PlaneBounds(plane);
+
+			if (plane->low < con_clipviewtop || plane->high > vid.height || plane->high > plane->low)
+				;
+			else {
+				// Put it in!
+				entry = R_CreateDrawNode(&nodehead);
+				entry->plane = plane;
+				entry->seg = ds;
+			}
+			ds->curline->polyseg->visplane = NULL;
+		}
+#endif
 		if (ds->maskedtexturecol)
 		{
-#ifdef POLYOBJECTS_PLANES
-			// Check for a polyobject plane, but only if this is a front line
-			if (ds->curline->polyseg && ds->curline->polyseg->visplane && !ds->curline->side) {
-				// Put it in!
-
-				entry = R_CreateDrawNode(&nodehead);
-				entry->plane = ds->curline->polyseg->visplane;
-				entry->seg = ds;
-				ds->curline->polyseg->visplane->polyobj = ds->curline->polyseg;
-				ds->curline->polyseg->visplane = NULL;
-			}
-#endif
-
 			entry = R_CreateDrawNode(&nodehead);
 			entry->seg = ds;
 		}


### PR DESCRIPTION
This is mostly cleanup, with the exception that polyobject planes should now behave somewhat better than they do in 2.1 currently (translucent polyobj planes should now always be actually translucent regardless of where you view them from, for instance). I can't claim I've fixed their rendering once and for all though, there may still be bugs for all I know...