### PR TITLE
Fix ceiling springs thrusting themselves down in midair on touch

### DIFF
--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -7685,6 +7685,10 @@ mobj_t *P_SpawnMobj(fixed_t x, fixed_t y, fixed_t z, mobjtype_t type)
 
 		if (mobj->type == MT_UNIDUS)
 			mobj->z -= FixedMul(mobj->info->mass, mobj->scale);
+
+		// defaults onground
+		if (mobj->z + mobj->height == mobj->ceilingz)
+			mobj->eflags |= MFE_ONGROUND;
 	}
 	else
 		mobj->z = z;


### PR DESCRIPTION
What the title says. I blame MFE_ONGROUND for being stupid, but for now I made it behave a bit better with flipped items at least.