### PR TITLE
Savegame hotfix

### DIFF
--- a/src/d_netcmd.c
+++ b/src/d_netcmd.c
@@ -3960,7 +3960,7 @@ static void Command_Archivetest_f(void)
 	}
 
 	// assign mobjnum
-	i = 0;
+	i = 1;
 	for (th = thinkercap.next; th != &thinkercap; th = th->next)
 		if (th->function.acp1 == (actionf_p1)P_MobjThinker)
 			((mobj_t *)th)->mobjnum = i++;

--- a/src/p_saveg.c
+++ b/src/p_saveg.c
@@ -3285,7 +3285,7 @@ void P_SaveNetGame(void)
 {
 	thinker_t *th;
 	mobj_t *mobj;
-	INT32 i = 0;
+	INT32 i = 1; // don't start from 0, it'd be confused with a blank pointer otherwise
 
 	CV_SaveNetVars(&save_p);
 	P_NetArchiveMisc();


### PR DESCRIPTION
This fixes the first mobj thinker added/read from $$$.sav not being relinked to other objects as their target/tracer/etc properly. In particular, this fixes Brak's electric shield disappearing for anyone joining a netgame playing ERCZ (as Brak happens to be the first object added/read in this case, and Brak is the shield's target).