### PR TITLE
Added transmaps to non modifying lump list.

### DIFF
--- a/src/w_wad.c
+++ b/src/w_wad.c
@@ -1223,6 +1223,7 @@ int W_VerifyNMUSlumps(const char *filename)
 		{"COLORMAP", 8},
 		{"PAL", 3},
 		{"CLM", 3},
+		{"TRANS", 5},
 		{NULL, 0},
 	};
 	return W_VerifyFile(filename, NMUSlist, false);


### PR DESCRIPTION
After going back over my PMs from the Message Board, I found myself wondering "Why _do_ transmaps cause a game modification, and is there anything I can do to prevent this?"

This was my solution.

Unfortunately its also untested, as I don't have a build environment set up, but judging from the surrounding code, such a fix should work.

I have no idea if this affects netgames in a manner that would cause desyncing.

Note that I /suppose/ that if another lump started with TRANS, say, a texture named TRANSEGG, or TRANS2S8, those might be able to be modified by this, but such a thing would require changes to the other listed names to make this impossible with any of them that its just not feasible.