### PR TITLE
A spike bug no more

### DIFF
--- a/src/p_map.c
+++ b/src/p_map.c
@@ -994,7 +994,7 @@ static boolean PIT_CheckThing(mobj_t *thing)
 			if (tmthing->player && tmthing->z + tmthing->height > topz
 				&& tmthing->z + tmthing->height < tmthing->ceilingz)
 			{
-				tmfloorz = tmceilingz = INT32_MIN; // block while in air
+				tmfloorz = tmceilingz = topz; // block while in air
 #ifdef ESLOPE
 				tmceilingslope = NULL;
 #endif
@@ -1037,7 +1037,7 @@ static boolean PIT_CheckThing(mobj_t *thing)
 			if (tmthing->player && tmthing->z < topz
 				&& tmthing->z > tmthing->floorz)
 			{
-				tmfloorz = tmceilingz = INT32_MAX; // block while in air
+				tmfloorz = tmceilingz = topz; // block while in air
 #ifdef ESLOPE
 				tmfloorslope = NULL;
 #endif


### PR DESCRIPTION
Jumping at spikes on FOFs in reverse gravity - most notably in ERZ3 - no longer teleports you downwards into the death pit beneath it.