### PR TITLE
TD rendering freeze fix

### DIFF
--- a/src/r_segs.c
+++ b/src/r_segs.c
@@ -706,10 +706,10 @@ void R_RenderMaskedSegRange(drawseg_t *ds, INT32 x1, INT32 x2)
 // Loop through R_DrawMaskedColumn calls
 static void R_DrawRepeatMaskedColumn(column_t *col)
 {
-	do {
+	while (sprtopscreen < sprbotscreen) {
 		R_DrawMaskedColumn(col);
 		sprtopscreen += dc_texheight*spryscale;
-	} while (sprtopscreen < sprbotscreen);
+	}
 }
 
 //


### PR DESCRIPTION
This is a fix for the Lava Mountain freeze issue from TD (KartKrew/TD#13) which can also occur in vanilla SRB2 as it turns out. Basically the issue occurs whenever an FOF with a single-patch texture with holes goes off the bottom of the screen far enough.