### PR TITLE
Dedicated console shift-down fix

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -187,7 +187,7 @@ UINT8 altdown = 0; // 0x1 left, 0x2 right
 //
 static inline void D_ModifierKeyResponder(event_t *ev)
 {
-	if (ev->type == ev_keydown) switch (ev->data1)
+	if (ev->type == ev_keydown || ev->type == ev_console) switch (ev->data1)
 	{
 		case KEY_LSHIFT: shiftdown |= 0x1; return;
 		case KEY_RSHIFT: shiftdown |= 0x2; return;


### PR DESCRIPTION
This fixes the special console window used by dedicated mode not properly telling the game when shift is held down since the console improvements added in 2.1.17. This means shift+1 is properly interpreted as "!" again rather than 1, shift+- should be "_" rather than "-", etc.

Sorry LJSonic your problems from pre-2.1.17 are probably just your keyboard being for a different locale than the one most SRB2 players play with, I'm not sure what can be done for the time being. =V

Fun note, you can see how the game interprets un-executed input to the console window by playing normal (not dedicated) SRB2 with `-console`, which creates a second window for the console just like you'd see for dedicated mode. Drop down the console on the main SRB2 window, switch to the console window and type something in (DON'T PRESS ENTER), and you'll see the input appearing in the input space in the console window at the same time!