### PR TITLE
Record attack custom exit fix

### DIFF
--- a/src/g_game.c
+++ b/src/g_game.c
@@ -2888,7 +2888,7 @@ static void G_DoCompleted(void)
 	if (nextmap < NUMMAPS && !mapheaderinfo[nextmap])
 		P_AllocMapHeader(nextmap);
 
-	if (skipstats)
+	if (skipstats && !modeattacking) // Don't skip stats if we're in record attack
 		G_AfterIntermission();
 	else
 	{


### PR DESCRIPTION
This fixes the bug reported here: http://mb.srb2.org/showthread.php?t=42342

Record Attack now no longer allows the tally to be skipped, whether by custom exits or by Lua etc.