### PR TITLE
Admin ban fix

### DIFF
--- a/src/d_clisrv.c
+++ b/src/d_clisrv.c
@@ -2696,7 +2696,7 @@ static void Got_KickCmd(UINT8 **p, INT32 playernum)
 
 	// If a verified admin banned someone, the server needs to know about it.
 	// If the playernum isn't zero (the server) then the server needs to record the ban.
-	if (server && playernum && msg == KICK_MSG_BANNED)
+	if (server && playernum && (msg == KICK_MSG_BANNED || msg == KICK_MSG_CUSTOM_BAN))
 	{
 		if (I_Ban && !I_Ban(playernode[(INT32)pnum]))
 		{


### PR DESCRIPTION
This possibly fixes the long-present bug with bans by verified admins, where they only count as a kick. This could be because they were using a custom message every time? Needs some testing to be sure this actually fixes it, I cannot test this fix by myself after all.

Merge request is for master, since the change is minimal and affects only the host. (in theory only the host needs an exe with the fix for it to work)