### PR TITLE
Admin ban fix

### DIFF
--- a/src/d_clisrv.c
+++ b/src/d_clisrv.c
@@ -2701,8 +2701,10 @@ static void Got_KickCmd(UINT8 **p, INT32 playernum)
 	{
 		if (I_Ban && !I_Ban(playernode[(INT32)pnum]))
 			CONS_Alert(CONS_WARNING, M_GetText("Too many bans! Geez, that's a lot of people you're excluding...\n"));
+#ifndef NONET
 		else
 			Ban_Add(reason);
+#endif
 	}
 
 	switch (msg)

--- a/src/d_clisrv.c
+++ b/src/d_clisrv.c
@@ -2531,7 +2531,7 @@ static void Command_Ban(void)
 			return;
 		else
 			WRITEUINT8(p, pn);
-		if (I_Ban && !I_Ban(node))
+		if (server && I_Ban && !I_Ban(node)) // only the server is allowed to do this right now
 		{
 			CONS_Alert(CONS_WARNING, M_GetText("Too many bans! Geez, that's a lot of people you're excluding...\n"));
 			WRITEUINT8(p, KICK_MSG_GO_AWAY);
@@ -2539,7 +2539,8 @@ static void Command_Ban(void)
 		}
 		else
 		{
-			Ban_Add(COM_Argv(2));
+			if (server) // only the server is allowed to do this right now
+				Ban_Add(COM_Argv(2));
 
 			if (COM_Argc() == 2)
 			{
@@ -2699,9 +2700,9 @@ static void Got_KickCmd(UINT8 **p, INT32 playernum)
 	if (server && playernum && (msg == KICK_MSG_BANNED || msg == KICK_MSG_CUSTOM_BAN))
 	{
 		if (I_Ban && !I_Ban(playernode[(INT32)pnum]))
-		{
 			CONS_Alert(CONS_WARNING, M_GetText("Too many bans! Geez, that's a lot of people you're excluding...\n"));
-		}
+		else
+			Ban_Add(reason);
 	}
 
 	switch (msg)

--- a/src/d_clisrv.c
+++ b/src/d_clisrv.c
@@ -2696,7 +2696,7 @@ static void Got_KickCmd(UINT8 **p, INT32 playernum)
 
 	// If a verified admin banned someone, the server needs to know about it.
 	// If the playernum isn't zero (the server) then the server needs to record the ban.
-	if (server && playernum && msg == KICK_MSG_BANNED)
+	if (server && playernum && (msg == KICK_MSG_BANNED || msg == KICK_MSG_CUSTOM_BAN))
 	{
 		if (I_Ban && !I_Ban(playernode[(INT32)pnum]))
 		{


### PR DESCRIPTION
Okay, THIS time admin bans should work properly. Turns out the relevant code for banning did not properly consider the case of admins doing the banning, at least until now.

Unlike my last attempt at fixing admin bans (!165), this one would require both host and admin to have the fix exe assuming everyone else would be using 2.1.17, so I'm merging to next instead of master.