### PR TITLE
Allowteamchange fix

### DIFF
--- a/src/d_netcmd.c
+++ b/src/d_netcmd.c
@@ -2116,7 +2116,7 @@ static void Command_Teamchange_f(void)
 		return;
 	}
 
-	if (!cv_allowteamchange.value && !NetPacket.packet.newteam) // allow swapping to spectator even in locked teams.
+	if (!cv_allowteamchange.value && NetPacket.packet.newteam) // allow swapping to spectator even in locked teams.
 	{
 		CONS_Alert(CONS_NOTICE, M_GetText("The server is not allowing team changes at the moment.\n"));
 		return;
@@ -2213,7 +2213,7 @@ static void Command_Teamchange2_f(void)
 		return;
 	}
 
-	if (!cv_allowteamchange.value && !NetPacket.packet.newteam) // allow swapping to spectator even in locked teams.
+	if (!cv_allowteamchange.value && NetPacket.packet.newteam) // allow swapping to spectator even in locked teams.
 	{
 		CONS_Alert(CONS_NOTICE, M_GetText("The server is not allowing team changes at the moment.\n"));
 		return;

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -3849,6 +3849,7 @@ static void M_ChangeLevel(INT32 choice)
 static void M_ConfirmSpectate(INT32 choice)
 {
 	(void)choice;
+	// We allow switching to spectator even if team changing is not allowed
 	M_ClearMenus(true);
 	COM_ImmedExecute("changeteam spectator");
 }
@@ -3856,6 +3857,11 @@ static void M_ConfirmSpectate(INT32 choice)
 static void M_ConfirmEnterGame(INT32 choice)
 {
 	(void)choice;
+	if (!cv_allowteamchange.value)
+	{
+		M_StartMessage(M_GetText("The server is not allowing\nteam changes at this time.\nPress a key.\n"), NULL, MM_NOTHING);
+		return;
+	}
 	M_ClearMenus(true);
 	COM_ImmedExecute("changeteam playing");
 }


### PR DESCRIPTION
Fixes "allowteamchange no" to actually work properly and NOT desync you from the game in most cases. You can now switch TO spectator freely (as intended it turns out), and switching FROM spectator is prohibited. The "Enter Game" menu option in Match/Tag now displays one of those blue window notices just like with "Change Teams" in CTF/Team Match if you cannot change teams right now. Everything else works as you'd expect.

The de-sync issue was originally reported here https://mb.srb2.org/showthread.php?p=789965#85