### PR TITLE
Precipitation sprite overflow fix

### DIFF
--- a/src/r_things.c
+++ b/src/r_things.c
@@ -891,11 +891,17 @@ static void R_DrawPrecipitationVisSprite(vissprite_t *vis)
 #endif
 	fixed_t frac;
 	patch_t *patch;
+	INT64 overflow_test;
 
 	//Fab : R_InitSprites now sets a wad lump number
 	patch = W_CacheLumpNum(vis->patch, PU_CACHE);
 	if (!patch)
 		return;
+
+	// Check for overflow
+	overflow_test = (INT64)centeryfrac - (((INT64)vis->texturemid*vis->scale)>>FRACBITS);
+	if (overflow_test < 0) overflow_test = -overflow_test;
+	if ((UINT64)overflow_test&0xFFFFFFFF80000000ULL) return; // fixed point mult would overflow
 
 	if (vis->transmap)
 	{


### PR DESCRIPTION
This fixes artifacts of rain/snow sprites appearing on-screen in levels that have rain/snow, if said sprites were high enough above the camera. This kind of thing was previously fixed for sprites of regular objects (and textures of FOFs?), but apparently the fix wasn't applied to sprites for precipitation as it turns out.

I found this most easily reproducable in SRB2TD's Stormy Streets level, because some of the invisible FOFs make raindrops continually splash right up at the sky ceiling itself. Position your camera underneath them right and ...voila, ghostly precip sprites apparently appearing. (You'll need to make a SOC to make the level playable in vanilla SRB2 mind)