### PR TITLE
Screenshot slots fix

### DIFF
--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -585,7 +585,7 @@ static const char *Newsnapshotfile(const char *pathname, const char *ext)
 
 		i += add * result;
 
-		if (add < 0 || add > 9999)
+		if (i < 0 || i > 9999)
 			return NULL;
 	}
 


### PR DESCRIPTION
Fix for this bug: https://mb.srb2.org/showthread.php?t=42508

The game should now print an error saying all 10000 slots have been used up. It was already there funnily enough, just someone goofed up in the code for finding the next screenshot name to use.