### PR TITLE
Linedef type 443 (Call Lua Function) fix

### DIFF
--- a/src/p_spec.c
+++ b/src/p_spec.c
@@ -3039,7 +3039,10 @@ static void P_ProcessLineSpecial(line_t *line, mobj_t *mo, sector_t *callsec)
 
 		case 443: // Calls a named Lua function
 #ifdef HAVE_BLUA
-			LUAh_LinedefExecute(line, mo, callsec);
+			if (line->text)
+				LUAh_LinedefExecute(line, mo, callsec);
+			else
+				CONS_Alert(CONS_WARNING, "Linedef %d is missing the hook name of the Lua function to call! (This should be given in the front texture fields)\n", line-lines);
 #else
 			CONS_Alert(CONS_ERROR, "The map is trying to run a Lua script, but this exe was not compiled with Lua support!\n");
 #endif


### PR DESCRIPTION
Fix for https://mb.srb2.org/showthread.php?t=42491

Note that the crash reported occurs only if Lua has been initialized (by having a Lua script loaded) and a LinedefExecute hook function has been added.