### PR TITLE
Jet Jaw crash fix

### DIFF
--- a/src/p_enemy.c
+++ b/src/p_enemy.c
@@ -1102,7 +1102,7 @@ void A_JetJawChomp(mobj_t *actor)
 	if (!actor->target || !(actor->target->flags & MF_SHOOTABLE)
 		|| actor->target->health <= 0 || !P_CheckSight(actor, actor->target))
 	{
-		P_SetMobjState(actor, actor->info->spawnstate);
+		P_SetMobjStateNF(actor, actor->info->spawnstate);
 		return;
 	}
 


### PR DESCRIPTION
Turns out not having MF_SHOOTABLE can cause the Jet Jaw to endlessly loop between the two states, until somehow LUA_CallAction inexplicably causes Z_StrDup to crash anyway (that one's a mystery to me, I'm not going to look into it right now). I tweaked A_JetJawChomp so this endless loop can't happen anymore.