### PR TITLE
obj folders fix

### DIFF
--- a/objs/DC/SDL/Debug/.gitignore
+++ b/objs/DC/SDL/Debug/.gitignore
@@ -1,0 +1,2 @@
+# DON'T REMOVE
+# This keeps the folder from disappearing

--- a/objs/DC/SDL/Release/.gitignore
+++ b/objs/DC/SDL/Release/.gitignore
@@ -1,0 +1,2 @@
+# DON'T REMOVE
+# This keeps the folder from disappearing

--- a/objs/Linux/SDL/Debug/.gitignore
+++ b/objs/Linux/SDL/Debug/.gitignore
@@ -1,0 +1,2 @@
+# DON'T REMOVE
+# This keeps the folder from disappearing

--- a/objs/Linux/SDL/Release/.gitignore
+++ b/objs/Linux/SDL/Release/.gitignore
@@ -1,0 +1,2 @@
+# DON'T REMOVE
+# This keeps the folder from disappearing

--- a/objs/Linux64/SDL/Debug/.gitignore
+++ b/objs/Linux64/SDL/Debug/.gitignore
@@ -1,0 +1,2 @@
+# DON'T REMOVE
+# This keeps the folder from disappearing

--- a/objs/Linux64/SDL/Release/.gitignore
+++ b/objs/Linux64/SDL/Release/.gitignore
@@ -1,0 +1,2 @@
+# DON'T REMOVE
+# This keeps the folder from disappearing

--- a/objs/Mingw/Debug/.gitignore
+++ b/objs/Mingw/Debug/.gitignore
@@ -1,0 +1,2 @@
+# DON'T REMOVE
+# This keeps the folder from disappearing

--- a/objs/Mingw/Release/.gitignore
+++ b/objs/Mingw/Release/.gitignore
@@ -1,0 +1,2 @@
+# DON'T REMOVE
+# This keeps the folder from disappearing

--- a/objs/Mingw/SDL/Debug/.gitignore
+++ b/objs/Mingw/SDL/Debug/.gitignore
@@ -1,0 +1,2 @@
+# DON'T REMOVE
+# This keeps the folder from disappearing

--- a/objs/Mingw/SDL/Release/.gitignore
+++ b/objs/Mingw/SDL/Release/.gitignore
@@ -1,0 +1,2 @@
+# DON'T REMOVE
+# This keeps the folder from disappearing

--- a/objs/Mingw64/Debug/.gitignore
+++ b/objs/Mingw64/Debug/.gitignore
@@ -1,0 +1,2 @@
+# DON'T REMOVE
+# This keeps the folder from disappearing

--- a/objs/Mingw64/Release/.gitignore
+++ b/objs/Mingw64/Release/.gitignore
@@ -1,0 +1,2 @@
+# DON'T REMOVE
+# This keeps the folder from disappearing

--- a/objs/Mingw64/SDL/Debug/.gitignore
+++ b/objs/Mingw64/SDL/Debug/.gitignore
@@ -1,0 +1,2 @@
+# DON'T REMOVE
+# This keeps the folder from disappearing

--- a/objs/Mingw64/SDL/Release/.gitignore
+++ b/objs/Mingw64/SDL/Release/.gitignore
@@ -1,0 +1,2 @@
+# DON'T REMOVE
+# This keeps the folder from disappearing

--- a/objs/PS3/SDL/Debug/.gitignore
+++ b/objs/PS3/SDL/Debug/.gitignore
@@ -1,0 +1,2 @@
+# DON'T REMOVE
+# This keeps the folder from disappearing

--- a/objs/PS3/SDL/Release/.gitignore
+++ b/objs/PS3/SDL/Release/.gitignore
@@ -1,0 +1,2 @@
+# DON'T REMOVE
+# This keeps the folder from disappearing

--- a/objs/PSP/SDL/Release/.gitignore
+++ b/objs/PSP/SDL/Release/.gitignore
@@ -1,0 +1,2 @@
+# DON'T REMOVE
+# This keeps the folder from disappearing

--- a/objs/SDL/Release/.gitignore
+++ b/objs/SDL/Release/.gitignore
@@ -1,0 +1,2 @@
+# DON'T REMOVE
+# This keeps the folder from disappearing

--- a/objs/VC/.gitignore
+++ b/objs/VC/.gitignore
@@ -1,0 +1,2 @@
+# DON'T REMOVE
+# This keeps the folder from disappearing

--- a/objs/VC9/.gitignore
+++ b/objs/VC9/.gitignore
@@ -1,0 +1,2 @@
+# DON'T REMOVE
+# This keeps the folder from disappearing

--- a/objs/Wii/SDL/Debug/.gitignore
+++ b/objs/Wii/SDL/Debug/.gitignore
@@ -1,0 +1,2 @@
+# DON'T REMOVE
+# This keeps the folder from disappearing

--- a/objs/Wii/SDL/Release/.gitignore
+++ b/objs/Wii/SDL/Release/.gitignore
@@ -1,0 +1,2 @@
+# DON'T REMOVE
+# This keeps the folder from disappearing

--- a/objs/WinCE/SDL/Release/.gitignore
+++ b/objs/WinCE/SDL/Release/.gitignore
@@ -1,0 +1,2 @@
+# DON'T REMOVE
+# This keeps the folder from disappearing

--- a/objs/djgppdos/Debug/.gitignore
+++ b/objs/djgppdos/Debug/.gitignore
@@ -1,0 +1,2 @@
+# DON'T REMOVE
+# This keeps the folder from disappearing

--- a/objs/djgppdos/Release/.gitignore
+++ b/objs/djgppdos/Release/.gitignore
@@ -1,0 +1,2 @@
+# DON'T REMOVE
+# This keeps the folder from disappearing

--- a/objs/nds/Debug/.gitignore
+++ b/objs/nds/Debug/.gitignore
@@ -1,0 +1,2 @@
+# DON'T REMOVE
+# This keeps the folder from disappearing

--- a/objs/nds/Release/.gitignore
+++ b/objs/nds/Release/.gitignore
@@ -1,0 +1,2 @@
+# DON'T REMOVE
+# This keeps the folder from disappearing


### PR DESCRIPTION
Partial backtrack of changes I made in !174. Apparently removing all the `.gitignore` files from `/objs`'s subfolders removed the only reason Git was keeping the folders alive (Git doesn't care about empty folders as it turns out). So now they have `.gitignore`s again, with a warning in each not to remove them