### PR TITLE
Invalid node hotfix

### DIFF
--- a/src/d_net.c
+++ b/src/d_net.c
@@ -716,6 +716,12 @@ void Net_CloseConnection(INT32 node)
 	if (!node)
 		return;
 
+	if (node >= MAXNETNODES) // prevent invalid nodes from crashing the game
+	{
+		CONS_Alert(CONS_WARNING, M_GetText("Net_CloseConnection: invalid node %d detected!\n"), node);
+		return;
+	}
+
 	nodes[node].flags |= NF_CLOSE;
 
 	// try to Send ack back (two army problem)


### PR DESCRIPTION
Quick hotfix to prevent `Net_CloseConnection` from crashing if the node's number is invalid. This is a merge to next because frankly I have no idea if this is v2.1.17-compatible or not anyway.