### PR TITLE
Missiles 'n slopes

### DIFF
--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -2363,7 +2363,7 @@ static boolean P_ZMovement(mobj_t *mo)
 			mo->z = mo->floorz;
 
 #ifdef ESLOPE
-		if (mo->standingslope) // You're still on the ground; why are we here?
+		if (!(mo->flags & MF_MISSILE) && mo->standingslope) // You're still on the ground; why are we here?
 		{
 			mo->momz = 0;
 			return true;


### PR DESCRIPTION
Fixed that thing where missiles like sliding up slopes for some reason.

This isn't a 1:1 fix compared to non-slopes - missiles still like stepping up over the borders of sloped sectors and will continue going as long as they never touch that ground again, whereas they can never step up on flat ones - but this fixes the most egregrious issue.