### PR TITLE
Dedicated bonuses fix

### DIFF
--- a/src/y_inter.c
+++ b/src/y_inter.c
@@ -965,7 +965,8 @@ void Y_StartIntermission(void)
 	}
 
 	// We couldn't display the intermission even if we wanted to.
-	if (dedicated) return;
+	// But we still need to give the players their score bonuses, dummy.
+	//if (dedicated) return;
 
 	// This should always exist, but just in case...
 	if(!mapheaderinfo[prevmap])


### PR DESCRIPTION
Fixes the issue reported here: https://mb.srb2.org/showthread.php?t=42530

What it turns out is going on is that making the game bail out in the middle of Y_StartIntermission if you're a dedicated server's host prevents the game from awarding the players bonuses in coop mode. Therefore it's not just special stage bonuses, but ANY kind of bonuses that can cause desyncs if someone loses all their lives.

This can be merged to master since it's a change only for dedicated server hosts, and should otherwise be compatible with 2.1.18.