### PR TITLE
Netcode hotfix

### DIFF
--- a/src/d_clisrv.c
+++ b/src/d_clisrv.c
@@ -3737,6 +3737,15 @@ FILESTAMP
 				tic_t tic = maketic;
 				UINT8 *textcmd;
 
+				// ignore if the textcmd size var is actually larger than it should be
+				if (BASEPACKETSIZE + netbuffer->u.textcmd[0] > (size_t)doomcom->datalength)
+				{
+					DEBFILE(va("GetPacket: Bad Textcmd packet size! (expected %d, actual %d)\n",
+					BASEPACKETSIZE + netbuffer->u.textcmd[0], doomcom->datalength));
+					Net_UnAcknowledgePacket(node);
+					break;
+				}
+
 				// check if tic that we are making isn't too large else we cannot send it :(
 				// doomcom->numslots+1 "+1" since doomcom->numslots can change within this time and sent time
 				j = software_MAXPACKETLENGTH

--- a/src/d_clisrv.c
+++ b/src/d_clisrv.c
@@ -3405,7 +3405,6 @@ static void HandlePacketFromAwayNode(SINT8 node)
 	switch (netbuffer->packettype)
 	{
 		case PT_ASKINFOVIAMS:
-
 			if (server && serverrunning)
 			{
 				INT32 clientnode;

--- a/src/d_clisrv.c
+++ b/src/d_clisrv.c
@@ -3405,14 +3405,16 @@ static void HandlePacketFromAwayNode(SINT8 node)
 	switch (netbuffer->packettype)
 	{
 		case PT_ASKINFOVIAMS:
-			if (ms_RoomId < 0) // ignore if we're not actually on the MS right now
-			{
-				Net_CloseConnection(node); // and yes, close connection
-				break;
-			}
+
 			if (server && serverrunning)
 			{
-				INT32 clientnode = I_NetMakeNode(netbuffer->u.msaskinfo.clientaddr);
+				INT32 clientnode;
+				if (ms_RoomId < 0) // ignore if we're not actually on the MS right now
+				{
+					Net_CloseConnection(node); // and yes, close connection
+					return;
+				}
+				clientnode = I_NetMakeNode(netbuffer->u.msaskinfo.clientaddr);
 				if (clientnode != -1)
 				{
 					SV_SendServerInfo(clientnode, (tic_t)LONG(netbuffer->u.msaskinfo.time));
@@ -3423,6 +3425,8 @@ static void HandlePacketFromAwayNode(SINT8 node)
 				else
 					Net_CloseConnection(node); // ...unless the IP address is not valid
 			}
+			else
+				Net_CloseConnection(node); // you're not supposed to get it, so ignore it
 			break;
 
 		case PT_ASKINFO:

--- a/src/d_clisrv.c
+++ b/src/d_clisrv.c
@@ -4004,9 +4004,6 @@ FILESTAMP
 
 	while (HGetPacket())
 	{
-		if (doomcom->remotenode == -1) // ...this should have been ignored already
-			continue; // might come from PT_NODETIMEOUT somehow though
-
 		node = (SINT8)doomcom->remotenode;
 
 		if (netbuffer->packettype == PT_CLIENTJOIN && server)
@@ -4039,10 +4036,8 @@ FILESTAMP
 		if (netbuffer->packettype == PT_PLAYERINFO)
 			continue; // We do nothing with PLAYERINFO, that's for the MS browser.
 
-		if (node < 0 || node >= MAXNETNODES) // THIS SHOULDN'T EVEN BE POSSIBLE
-			; //CONS_Printf("Received packet from node %d!\n", (int)node);
 		// Packet received from someone already playing
-		else if (nodeingame[node])
+		if (nodeingame[node])
 			HandlePacketFromPlayer(node);
 		// Packet received from someone not playing
 		else

--- a/src/d_clisrv.c
+++ b/src/d_clisrv.c
@@ -3609,6 +3609,8 @@ FILESTAMP
 	{
 // -------------------------------------------- SERVER RECEIVE ----------
 		case PT_RESYNCHGET:
+			if (client)
+				break;
 			SV_AcknowledgeResynchAck(netconsole, netbuffer->u.resynchgot);
 			break;
 		case PT_CLIENTCMD:

--- a/src/d_clisrv.c
+++ b/src/d_clisrv.c
@@ -3677,7 +3677,8 @@ FILESTAMP
 			}
 
 			// Splitscreen cmd
-			if (netbuffer->packettype == PT_CLIENT2CMD && nodetoplayer2[node] >= 0)
+			if ((netbuffer->packettype == PT_CLIENT2CMD || netbuffer->packettype == PT_CLIENT2MIS)
+				&& nodetoplayer2[node] >= 0)
 				G_MoveTiccmd(&netcmds[maketic%BACKUPTICS][(UINT8)nodetoplayer2[node]],
 					&netbuffer->u.client2pak.cmd2, 1);
 

--- a/src/d_clisrv.c
+++ b/src/d_clisrv.c
@@ -3556,11 +3556,6 @@ static void HandlePacketFromAwayNode(SINT8 node)
 			break;
 
 		case PT_REQUESTFILE:
-			if (node != servernode) // nope you're not the server
-			{
-				Net_CloseConnection(node);
-				break;
-			}
 			if (server)
 				Got_RequestFilePak(node);
 			break;

--- a/src/d_clisrv.c
+++ b/src/d_clisrv.c
@@ -3751,8 +3751,8 @@ FILESTAMP
 				// BASEPACKETSIZE + 1 (for size) + textcmd[0] should == datalength
 				if (netbuffer->u.textcmd[0] > (size_t)doomcom->datalength-BASEPACKETSIZE-1)
 				{
-					DEBFILE(va("GetPacket: Bad Textcmd packet size! (expected %d, actual %d, node %u, player %d)\n",
-					netbuffer->u.textcmd[0], (size_t)doomcom->datalength-BASEPACKETSIZE-1,
+					DEBFILE(va("GetPacket: Bad Textcmd packet size! (expected %d, actual %s, node %u, player %d)\n",
+					netbuffer->u.textcmd[0], sizeu1((size_t)doomcom->datalength-BASEPACKETSIZE-1),
 						node, netconsole));
 					Net_UnAcknowledgePacket(node);
 					break;

--- a/src/d_clisrv.c
+++ b/src/d_clisrv.c
@@ -3936,6 +3936,9 @@ FILESTAMP
 
 	while (HGetPacket())
 	{
+		if (doomcom->remotenode == -1) // ...this should have been ignored already
+			continue; // might come from PT_NODETIMEOUT somehow though
+
 		node = (SINT8)doomcom->remotenode;
 
 		if (netbuffer->packettype == PT_CLIENTJOIN && server)
@@ -3968,8 +3971,10 @@ FILESTAMP
 		if (netbuffer->packettype == PT_PLAYERINFO)
 			continue; // We do nothing with PLAYERINFO, that's for the MS browser.
 
+		if (node < 0 || node >= MAXNETNODES) // THIS SHOULDN'T EVEN BE POSSIBLE
+			; //CONS_Printf("Received packet from node %d!\n", (int)node);
 		// Packet received from someone already playing
-		if (nodeingame[node])
+		else if (nodeingame[node])
 			HandlePacketFromPlayer(node);
 		// Packet received from someone not playing
 		else

--- a/src/d_clisrv.c
+++ b/src/d_clisrv.c
@@ -3402,6 +3402,14 @@ static void HandlePacketFromAwayNode(SINT8 node)
 	if (node != servernode)
 		DEBFILE(va("Received packet from unknown host %d\n", node));
 
+// macro for packets that should only be sent by the server
+// if it is NOT from the server, bail out and close the connection!
+#define SERVERONLY \
+			if (node != servernode) \
+			{ \
+				Net_CloseConnection(node); \
+				break; \
+			}
 	switch (netbuffer->packettype)
 	{
 		case PT_ASKINFOVIAMS:
@@ -3443,11 +3451,7 @@ static void HandlePacketFromAwayNode(SINT8 node)
 				Net_CloseConnection(node);
 				break;
 			}
-			if (node != servernode) // nope you're not the server
-			{
-				Net_CloseConnection(node);
-				break;
-			}
+			SERVERONLY
 			if (cl_mode == CL_WAITJOINRESPONSE)
 			{
 				// Save the reason so it can be displayed after quitting the netgame
@@ -3479,11 +3483,7 @@ static void HandlePacketFromAwayNode(SINT8 node)
 				Net_CloseConnection(node);
 				break;
 			}
-			if (node != servernode) // nope you're not the server
-			{
-				Net_CloseConnection(node);
-				break;
-			}
+			SERVERONLY
 			/// \note how would this happen? and is it doing the right thing if it does?
 			if (cl_mode != CL_WAITJOINRESPONSE)
 				break;
@@ -3547,11 +3547,7 @@ static void HandlePacketFromAwayNode(SINT8 node)
 				Net_CloseConnection(node);
 				break;
 			}
-			if (node != servernode) // nope you're not the server
-			{
-				Net_CloseConnection(node);
-				break;
-			}
+			SERVERONLY
 			Got_Filetxpak();
 			break;
 
@@ -3580,6 +3576,7 @@ static void HandlePacketFromAwayNode(SINT8 node)
 			break; // Ignore it
 
 	}
+#undef SERVERONLY
 }
 
 /** Handles a packet received from a node that is in game

--- a/src/d_clisrv.c
+++ b/src/d_clisrv.c
@@ -3405,13 +3405,23 @@ static void HandlePacketFromAwayNode(SINT8 node)
 	switch (netbuffer->packettype)
 	{
 		case PT_ASKINFOVIAMS:
+			if (ms_RoomId < 0) // ignore if we're not actually on the MS right now
+			{
+				Net_CloseConnection(node); // and yes, close connection
+				break;
+			}
 			if (server && serverrunning)
 			{
 				INT32 clientnode = I_NetMakeNode(netbuffer->u.msaskinfo.clientaddr);
-				SV_SendServerInfo(clientnode, (tic_t)LONG(netbuffer->u.msaskinfo.time));
-				SV_SendPlayerInfo(clientnode); // Send extra info
-				Net_CloseConnection(clientnode);
-				// Don't close connection to MS.
+				if (clientnode != -1)
+				{
+					SV_SendServerInfo(clientnode, (tic_t)LONG(netbuffer->u.msaskinfo.time));
+					SV_SendPlayerInfo(clientnode); // Send extra info
+					Net_CloseConnection(clientnode);
+					// Don't close connection to MS...
+				}
+				else
+					Net_CloseConnection(node); // ...unless the IP address is not valid
 			}
 			break;
 

--- a/src/d_clisrv.c
+++ b/src/d_clisrv.c
@@ -3553,7 +3553,12 @@ static void HandlePacketFromAwayNode(SINT8 node)
 
 		case PT_REQUESTFILE:
 			if (server)
-				Got_RequestFilePak(node);
+			{
+				if (!cv_downloading.value || !Got_RequestFilePak(node))
+					Net_CloseConnection(node); // close connection if one of the requested files could not be sent, or you disabled downloading anyway
+			}
+			else
+				Net_CloseConnection(node); // nope
 			break;
 
 		case PT_NODETIMEOUT:

--- a/src/d_net.c
+++ b/src/d_net.c
@@ -1124,27 +1124,22 @@ boolean HGetPacket(void)
 	// Get a packet from self
 	if (rebound_tail != rebound_head)
 	{
-		while (true) // loop until we found a valid packet, or we ran out of packets
-		{ // provided MAXREBOUND is not all that large this shouldn't take too long
-			if (rebound_tail == rebound_head)
-				break; // just give up, none of them were any good somehow
-			M_Memcpy(netbuffer, &reboundstore[rebound_tail], reboundsize[rebound_tail]);
-			doomcom->datalength = reboundsize[rebound_tail];
-			if (netbuffer->packettype == PT_NODETIMEOUT)
-				doomcom->remotenode = netbuffer->u.textcmd[0];
-			else
-				doomcom->remotenode = 0;
+		M_Memcpy(netbuffer, &reboundstore[rebound_tail], reboundsize[rebound_tail]);
+		doomcom->datalength = reboundsize[rebound_tail];
+		if (netbuffer->packettype == PT_NODETIMEOUT)
+			doomcom->remotenode = netbuffer->u.textcmd[0];
+		else
+			doomcom->remotenode = 0;
 
-			rebound_tail = (rebound_tail+1) % MAXREBOUND;
+		rebound_tail = (rebound_tail+1) % MAXREBOUND;
 
-			if (doomcom->remotenode == -1) // wait hang on what?
-				continue; // ignore it, look for the next packet
+		if (doomcom->remotenode == -1) // wait hang on what?
+			return true; // there might still be packets from others though, so don't return false
 #ifdef DEBUGFILE
-			if (debugfile)
-				DebugPrintpacket("GETLOCAL");
+		if (debugfile)
+			DebugPrintpacket("GETLOCAL");
 #endif
-			return true;
-		}
+		return true;
 	}
 
 	if (!netgame)

--- a/src/d_net.c
+++ b/src/d_net.c
@@ -1133,8 +1133,6 @@ boolean HGetPacket(void)
 
 		rebound_tail = (rebound_tail+1) % MAXREBOUND;
 
-		if (doomcom->remotenode == -1) // wait hang on what?
-			return true; // there might still be packets from others though, so don't return false
 #ifdef DEBUGFILE
 		if (debugfile)
 			DebugPrintpacket("GETLOCAL");

--- a/src/d_net.c
+++ b/src/d_net.c
@@ -711,6 +711,10 @@ void Net_CloseConnection(INT32 node)
 #else
 	INT32 i;
 	boolean forceclose = (node & FORCECLOSE) != 0;
+
+	if (node == -1)
+		return; // nope, just ignore it
+
 	node &= ~FORCECLOSE;
 
 	if (!node)
@@ -718,7 +722,7 @@ void Net_CloseConnection(INT32 node)
 
 	if (node < 0 || node >= MAXNETNODES) // prevent invalid nodes from crashing the game
 	{
-		CONS_Alert(CONS_WARNING, M_GetText("Net_CloseConnection: invalid node %d detected!\n"), node);
+		//CONS_Alert(CONS_WARNING, M_GetText("Net_CloseConnection: invalid node %d detected!\n"), node);
 		return;
 	}
 
@@ -1128,6 +1132,9 @@ boolean HGetPacket(void)
 			doomcom->remotenode = 0;
 
 		rebound_tail = (rebound_tail+1) % MAXREBOUND;
+
+		if (doomcom->remotenode == -1) // wait hang on what?
+			return true; // there might still be packets from others though, so don't return false
 #ifdef DEBUGFILE
 		if (debugfile)
 			DebugPrintpacket("GETLOCAL");

--- a/src/d_net.c
+++ b/src/d_net.c
@@ -713,7 +713,10 @@ void Net_CloseConnection(INT32 node)
 	boolean forceclose = (node & FORCECLOSE) != 0;
 
 	if (node == -1)
+	{
+		DEBFILE(M_GetText("Net_CloseConnection: node -1 detected!\n"));
 		return; // nope, just ignore it
+	}
 
 	node &= ~FORCECLOSE;
 
@@ -722,7 +725,7 @@ void Net_CloseConnection(INT32 node)
 
 	if (node < 0 || node >= MAXNETNODES) // prevent invalid nodes from crashing the game
 	{
-		//CONS_Alert(CONS_WARNING, M_GetText("Net_CloseConnection: invalid node %d detected!\n"), node);
+		DEBFILE(va(M_GetText("Net_CloseConnection: invalid node %d detected!\n"), node));
 		return;
 	}
 
@@ -1132,7 +1135,6 @@ boolean HGetPacket(void)
 			doomcom->remotenode = 0;
 
 		rebound_tail = (rebound_tail+1) % MAXREBOUND;
-
 #ifdef DEBUGFILE
 		if (debugfile)
 			DebugPrintpacket("GETLOCAL");

--- a/src/d_netfil.c
+++ b/src/d_netfil.c
@@ -495,7 +495,7 @@ static boolean SV_SendFile(INT32 node, const char *filename, UINT8 fileid)
 	char wadfilename[MAX_WADPATH];
 
 	if (cv_noticedownload.value)
-		CONS_Printf("Sending file \"%s\" to node %d\n", filename, node);
+		CONS_Printf("Sending file \"%s\" to node %d (%s)\n", filename, node, I_GetNodeAddress(node));
 
 	// Find the last file in the list and set a pointer to its "next" field
 	q = &transfer[node].txlist;

--- a/src/d_netfil.c
+++ b/src/d_netfil.c
@@ -644,6 +644,7 @@ static void SV_RemoveFileSendList(INT32 node)
 		// Remove the file request from the list
 		transfer[node].txlist = p->next;
 		free(p);
+		p = transfer[node].txlist;
 		// Indicate that the transmission is over (if for some reason it had started)
 		transfer[node].currentfile = NULL;
 		filestosend--;

--- a/src/d_netfil.h
+++ b/src/d_netfil.h
@@ -69,7 +69,7 @@ boolean SV_SendingFile(INT32 node);
 
 boolean CL_CheckDownloadable(void);
 boolean CL_SendRequestFile(void);
-void Got_RequestFilePak(INT32 node);
+boolean Got_RequestFilePak(INT32 node);
 
 void SV_AbortSendFiles(INT32 node);
 void CloseNetFile(void);


### PR DESCRIPTION
Various netcode fixes are included in this branch. Most important of all of course is a fix for the Net_CloseConnection invalid node -32769 detected message thing, or rather what actually caused that to occur.

It's a merge to master since everything here should be compatible with 2.1.18: the only main changes are related to recieving packets (whether you're the host of a netgame or a client), which AFAIK shouldn't cause desyncs if you played with these fixes on a 2.1.18-hosted netgame (or hosted a netgame with the fixes and 2.1.18-using players join you).