### PR TITLE
Exit your server desync fix

### DIFF
--- a/src/d_netcmd.c
+++ b/src/d_netcmd.c
@@ -1569,8 +1569,13 @@ void D_MapChange(INT32 mapnum, INT32 newgametype, boolean pultmode, boolean rese
 		mapchangepending = 0;
 		// spawn the server if needed
 		// reset players if there is a new one
-		if (!(adminplayer == consoleplayer) && SV_SpawnServer())
-			buf[0] &= ~(1<<1);
+		if (!(adminplayer == consoleplayer))
+		{
+			if (SV_SpawnServer())
+				buf[0] &= ~(1<<1);
+			if (!Playing()) // you failed to start a server somehow, so cancel the map change
+				return;
+		}
 
 		// Kick bot from special stages
 		if (botskin)


### PR DESCRIPTION
This branch fixes this bug: https://mb.srb2.org/showthread.php?t=41811

Here's an explanation of how this bug is actually happening:
* Pressing Enter with "Start" selected calls `D_MapChange` to make a map change command. (Note that part of it is actually delayed because it's called from a menu, but this isn't relevant to the bug)
* `D_MapChange` itself calls `SV_StartServer` to start up the server, if you're supposed to be the server player.
* Pressing Esc while starting up a server like shown in the gif causes the server to be cancelled, and go back to the title screen.
* HOWEVER, since we're still in `D_MapChange`, the map change command is made anyway.
* Since we're not in a netgame as expected, no random seed is added, and the map change command has a total size of 9 bytes (1 for the id + 8 for the actual data). This is then stored in the net command buffer. The random seed would add another 4 bytes if it WAS added, note.
* Next time you start a server, and let it work as normal, two more net commands are added: an "add player" command (size 3), and a map change command (size 13, including random seed this time). Your net command buffer now has a total size of **25** (9 + 3 + 13).
* This net command buffer is then sent as a `PT_TEXTCMD` packet to yourself.
* SRB2 recieves the `PT_TEXTCMD` you sent to yourself, and some time later, tries to run the net commands stored in it.
* The first map command is read as if it's size 13 rather than size 9 (it isn't), mistakeningly thinking a 4-byte random seed is stored (since you ARE in a netgame now). This means your buffer reads what it thinks is the next net command starting from position **[14]** in the buffer.
* Bad luck, it gets an id of **0**, which doesn't correspond with any net command!
* This message is then printed in the console:

> WARNING: Got unknown net command [14]=0 (max 25)

* The game subsequently kicks you out the server with a "desynch" message.

tl;dr The game doesn't correctly cancel the map change when you cancel the server with Esc like that. This is not a good thing.