### PR TITLE
NiGHTS capsule color fix

### DIFF
--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -7807,6 +7807,7 @@ mobj_t *P_SpawnMobj(fixed_t x, fixed_t y, fixed_t z, mobjtype_t type)
 			break;
 		case MT_EGGCAPSULE:
 			mobj->extravalue1 = -1; // timer for how long a player has been at the capsule
+			break;
 		case MT_REDTEAMRING:
 			mobj->color = skincolor_redteam;
 			break;


### PR DESCRIPTION
This fixes the Egg/Ideya capsule from NiGHTS stages being given SKINCOLOR_RED as a color. Not really relevant for vanilla SRB2 (since it doesn't use green in the sprite), but it may be relevant for custom mods using a custom NiGHTS capsule sprite that happens to use green.