### PR TITLE
Ignore askinfoviams

### DIFF
--- a/src/d_clisrv.c
+++ b/src/d_clisrv.c
@@ -3413,6 +3413,7 @@ static void HandlePacketFromAwayNode(SINT8 node)
 	switch (netbuffer->packettype)
 	{
 		case PT_ASKINFOVIAMS:
+#if 0
 			if (server && serverrunning)
 			{
 				INT32 clientnode;
@@ -3434,6 +3435,9 @@ static void HandlePacketFromAwayNode(SINT8 node)
 			}
 			else
 				Net_CloseConnection(node); // you're not supposed to get it, so ignore it
+#else
+			Net_CloseConnection(node);
+#endif
 			break;
 
 		case PT_ASKINFO:


### PR DESCRIPTION
Turns out PT_ASKINFOVIAMS is an obsolete packet type anyway, the MS doesn't send it at all. So let's just ignore it in the netcode then. (the online page just acts like a client and sends PT_ASKINFO, and is not part of the MS itself)