### PR TITLE
Ping-related code fix

### DIFF
--- a/src/d_clisrv.c
+++ b/src/d_clisrv.c
@@ -3971,7 +3971,7 @@ FILESTAMP
 			if (client)
 			{
 				INT32 i;
-				for (i = 0; i < MAXNETNODES; i++)
+				for (i = 0; i < MAXPLAYERS; i++)
 					if (playeringame[i])
 						playerpingtable[i] = (tic_t)netbuffer->u.pingtable[i];
 			}

--- a/src/d_clisrv.c
+++ b/src/d_clisrv.c
@@ -4560,16 +4560,11 @@ void NetUpdate(void)
 
 	gametime = nowtime;
 
-	if (!(gametime % 255) && netgame && server)
-	{
-#ifdef NEWPING
-		PingUpdate();
-#endif
-	}
-
 #ifdef NEWPING
 	if (server)
 	{
+		if (netgame && !(gametime % 255))
+			PingUpdate();
 		// update node latency values so we can take an average later.
 		for (i = 0; i < MAXPLAYERS; i++)
 			if (playeringame[i])

--- a/src/d_clisrv.c
+++ b/src/d_clisrv.c
@@ -4529,8 +4529,8 @@ static inline void PingUpdate(void)
 	}
 
 	//send out our ping packets
-	for (i = 0; i < MAXPLAYERS; i++)
-		if (playeringame[i])
+	for (i = 0; i < MAXNETNODES; i++)
+		if (nodeingame[i])
 			HSendPacket(i, true, 0, sizeof(INT32) * MAXPLAYERS);
 
 	pingmeasurecount = 1; //Reset count
@@ -4571,9 +4571,9 @@ void NetUpdate(void)
 	if (server)
 	{
 		// update node latency values so we can take an average later.
-		for (i = 0; i < MAXNETNODES; i++)
+		for (i = 0; i < MAXPLAYERS; i++)
 			if (playeringame[i])
-				realpingtable[i] += G_TicsToMilliseconds(GetLag(i));
+				realpingtable[i] += G_TicsToMilliseconds(GetLag(playernode[i]));
 		pingmeasurecount++;
 	}
 #endif


### PR DESCRIPTION
Somehow, the part of the netcode for calculating the players' pings in a netgame frequently gets the concepts of nodes and players mixed up, which is probably not a good thing. This branch of course fixes those slipups.

I originally based this branch on master to be merged to it (since it only fixed issues on the host's side), but after finding another issue with clients receiving PT_PING from the server, I decided to make this a merge to next instead.