### PR TITLE
Polyobject seg render fix

### DIFF
--- a/src/hardware/hw_main.c
+++ b/src/hardware/hw_main.c
@@ -3722,6 +3722,9 @@ static void HWR_Subsector(size_t num)
 
 		while (count--)
 		{
+#ifdef POLYOBJECTS
+				if (!line->polyseg) // ignore segs that belong to polyobjects
+#endif
 				HWR_AddLine(line);
 				line++;
 		}

--- a/src/r_bsp.c
+++ b/src/r_bsp.c
@@ -1222,6 +1222,9 @@ static void R_Subsector(size_t num)
 	while (count--)
 	{
 //		CONS_Debug(DBG_GAMELOGIC, "Adding normal line %d...(%d)\n", line->linedef-lines, leveltime);
+#ifdef POLYOBJECTS
+		if (!line->polyseg) // ignore segs that belong to polyobjects
+#endif
 		R_AddLine(line);
 		line++;
 		curline = NULL; /* cph 2001/11/18 - must clear curline now we're done with it, so stuff doesn't try using it for other things */


### PR DESCRIPTION
This fixes both Software and OpenGL renderers so that polyobject segs aren't drawn if the game is drawing the actual subsectors they're from (outside the main level, where the polyobject walls were pre-spawn). They should only appear as part of the polyobject itself in-level.

This means a few glitches with polyobjects are probably fixed: for instance in Software mode, polyobject walls sometimes appear through level boundaries (and make everything above/below vanish, turning into HOM or skybox), if the BSP rendering code happens to find one of the subsectors said segs came from outside the level. I don't think anything similar happens in OpenGL, though I'm sure some unwanted typecasting is happening as a result of attempting to draw the segs. (And it fixes a crash in 2.2 anyway.)