### PR TITLE
Record Attack ghosts scale fix

### DIFF
--- a/src/g_game.c
+++ b/src/g_game.c
@@ -3872,7 +3872,7 @@ void G_GhostAddColor(ghostcolor_t color)
 	ghostext.color = (UINT8)color;
 }
 
-void G_GhostAddScale(UINT16 scale)
+void G_GhostAddScale(fixed_t scale)
 {
 	if (!demorecording || !(demoflags & DF_GHOST))
 		return;

--- a/src/g_game.h
+++ b/src/g_game.h
@@ -139,7 +139,7 @@ void G_GhostAddSpin(void);
 void G_GhostAddRev(void);
 void G_GhostAddColor(ghostcolor_t color);
 void G_GhostAddFlip(void);
-void G_GhostAddScale(UINT16 scale);
+void G_GhostAddScale(fixed_t scale);
 void G_GhostAddHit(mobj_t *victim);
 void G_WriteGhostTic(mobj_t *ghost);
 void G_ConsGhostTic(void);


### PR DESCRIPTION
This fixes how changes to the player's scale are recorded in Record Attack demos, so ghosts of your demos don't disappear when they attempt to change to scales >= FRACUNIT (if they didn't change scales at all they were unaffected).

Have some gifs for comparison:
* A demo recorded without the fix:
 ![Bad](https://dl.dropboxusercontent.com/s/tk9x8nptzhw7yb1/srb20106.gif)
* A demo recorded with the fix:
![Good](https://dl.dropboxusercontent.com/s/b4h4iuiwbh0voos/srb20107.gif)