### PR TITLE
Fix for Lua's "PlayerSpawn" hook

### DIFF
--- a/src/g_game.c
+++ b/src/g_game.c
@@ -2288,6 +2288,9 @@ void G_SpawnPlayer(INT32 playernum, boolean starpost)
 	if (starpost) //Don't even bother with looking for a place to spawn.
 	{
 		P_MovePlayerToStarpost(playernum);
+#ifdef HAVE_BLUA
+		LUAh_PlayerSpawn(&players[playernum]); // Lua hook for player spawning :)
+#endif
 		return;
 	}
 


### PR DESCRIPTION
This fixes how functions for the "PlayerSpawn" Lua hook aren't called when the player respawns at a starpost instead of at a map thing start.

(Note to Lua scripters who may want to adjust their scripts accordingly with this in future, checking if `player.starposttime` is non-zero is the best way to detect if you're spawning at a starpost or not.)