### PR TITLE
Charability trigger hotfix

### DIFF
--- a/src/p_spec.c
+++ b/src/p_spec.c
@@ -1742,7 +1742,7 @@ boolean P_RunTriggerLinedef(line_t *triggerline, mobj_t *actor, sector_t *caller
 		case 305: // continuous
 		case 306: // each time
 		case 307: // once
-			if (!(actor && actor->player && actor->player->charability != dist/10))
+			if (!(actor && actor->player && actor->player->charability == dist/10))
 				return false;
 			break;
 		case 309: // continuous


### PR DESCRIPTION
Apparently when I made `P_RunTriggerSpecial` less than 3 years ago (August 2014) and cleaned up the trigger linedef code, I accidentally inverted the ability check for linedef types 305-307 by mistake, thereby causing the linedefs to activate for anyone EXCEPT those with the ability instead. Whoops.