### PR TITLE
P_FloorzAtPos slope fix

### DIFF
--- a/src/p_map.c
+++ b/src/p_map.c
@@ -4000,6 +4000,11 @@ fixed_t P_FloorzAtPos(fixed_t x, fixed_t y, fixed_t z, fixed_t height)
 	sector_t *sec = R_PointInSubsector(x, y)->sector;
 	fixed_t floorz = sec->floorheight;
 
+#ifdef ESLOPE
+	if (sec->f_slope)
+		floorz = P_GetZAt(sec->f_slope, x, y);
+#endif
+
 	// Intercept the stupid 'fall through 3dfloors' bug Tails 03-17-2002
 	if (sec->ffloors)
 	{


### PR DESCRIPTION
This fixes P_FloorzAtPos not considering the normal floor slope of the sector the given x/y/z coord is in, if one is set. Though apparently it already did consider FOF slopes, huh.