### PR TITLE
Fix for window being offcenter

### DIFF
--- a/src/sdl/i_video.c
+++ b/src/sdl/i_video.c
@@ -194,7 +194,7 @@ static void SDLSetMode(INT32 width, INT32 height, SDL_bool fullscreen)
 			}
 			// Reposition window only in windowed mode
 			SDL_SetWindowSize(window, width, height);
-			SDL_SetWindowPosition(window, SDL_WINDOWPOS_CENTERED_DISPLAY(1), SDL_WINDOWPOS_CENTERED_DISPLAY(1));
+			SDL_SetWindowPosition(window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
 		}
 	}
 	else


### PR DESCRIPTION
Fix issue [Windows Quick], where the window would be set off-center. I only tested this on Fedora 26 at 640x400, so I don't really know how this affects other OSes.

[Windows Quick]: http://git.magicalgirl.moe/STJr/SRB2/issues/25