### PR TITLE
P_RespawnSpecials mobj type hotfix

### DIFF
--- a/src/lua_hooklib.c
+++ b/src/lua_hooklib.c
@@ -231,6 +231,8 @@ boolean LUAh_MobjHook(mobj_t *mo, enum hook which)
 	if (!gL || !(hooksAvailable[which/8] & (1<<(which%8))))
 		return false;
 
+	I_Assert(mo->type < NUMMOBJTYPES);
+
 	lua_settop(gL, 0);
 
 	// Look for all generic mobj hooks
@@ -406,6 +408,8 @@ UINT8 LUAh_MobjCollideHook(mobj_t *thing1, mobj_t *thing2, enum hook which)
 	if (!gL || !(hooksAvailable[which/8] & (1<<(which%8))))
 		return 0;
 
+	I_Assert(thing1->type < NUMMOBJTYPES);
+
 	lua_settop(gL, 0);
 
 	// Look for all generic mobj collision hooks
@@ -479,6 +483,8 @@ boolean LUAh_MobjThinker(mobj_t *mo)
 	if (!gL || !(hooksAvailable[hook_MobjThinker/8] & (1<<(hook_MobjThinker%8))))
 		return false;
 
+	I_Assert(mo->type < NUMMOBJTYPES);
+
 	lua_settop(gL, 0);
 
 	// Look for all generic mobj thinker hooks
@@ -531,6 +537,8 @@ boolean LUAh_TouchSpecial(mobj_t *special, mobj_t *toucher)
 	boolean hooked = false;
 	if (!gL || !(hooksAvailable[hook_TouchSpecial/8] & (1<<(hook_TouchSpecial%8))))
 		return 0;
+
+	I_Assert(special->type < NUMMOBJTYPES);
 
 	lua_settop(gL, 0);
 
@@ -594,6 +602,8 @@ UINT8 LUAh_ShouldDamage(mobj_t *target, mobj_t *inflictor, mobj_t *source, INT32
 	UINT8 shouldDamage = 0; // 0 = default, 1 = force yes, 2 = force no.
 	if (!gL || !(hooksAvailable[hook_ShouldDamage/8] & (1<<(hook_ShouldDamage%8))))
 		return 0;
+
+	I_Assert(target->type < NUMMOBJTYPES);
 
 	lua_settop(gL, 0);
 
@@ -676,6 +686,8 @@ boolean LUAh_MobjDamage(mobj_t *target, mobj_t *inflictor, mobj_t *source, INT32
 	if (!gL || !(hooksAvailable[hook_MobjDamage/8] & (1<<(hook_MobjDamage%8))))
 		return 0;
 
+	I_Assert(target->type < NUMMOBJTYPES);
+
 	lua_settop(gL, 0);
 
 	// Look for all generic mobj damage hooks
@@ -746,6 +758,8 @@ boolean LUAh_MobjDeath(mobj_t *target, mobj_t *inflictor, mobj_t *source)
 	boolean hooked = false;
 	if (!gL || !(hooksAvailable[hook_MobjDeath/8] & (1<<(hook_MobjDeath%8))))
 		return 0;
+
+	I_Assert(target->type < NUMMOBJTYPES);
 
 	lua_settop(gL, 0);
 

--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -8332,6 +8332,16 @@ void P_RespawnSpecials(void)
 			if (mthing->type == mobjinfo[i].doomednum)
 				break;
 
+		if (i == NUMMOBJTYPES) // prevent creation of objects with this type -- Monster Iestyn 17/12/17
+		{
+			// 3D Mode start Thing is unlikely to be added to the que,
+			// so don't bother checking for that specific type
+			CONS_Alert(CONS_WARNING, M_GetText("P_RespawnSpecials: Unknown thing type %d attempted to respawn at (%d, %d)\n"), mthing->type, mthing->x, mthing->y);
+			// pull it from the que
+			iquetail = (iquetail+1)&(ITEMQUESIZE-1);
+			return;
+		}
+
 		//CTF rings should continue to respawn as normal rings outside of CTF.
 		if (gametype != GT_CTF)
 		{


### PR DESCRIPTION
Prevents P_RespawnSpecials from creating any bizarre objects of type NUMMOBJTYPES, created by simultaneously removing object types that respawn in Match (such as rings or weapons) and changing their map things' type numbers to be unable to spawn anything afterwards. That is, unless you applied MF2_DONTRESPAWN to the original objects being removed.