### PR TITLE
Add support for overriding the ESC key

### DIFF
--- a/src/g_game.c
+++ b/src/g_game.c
@@ -1856,6 +1856,12 @@ boolean G_Responder(event_t *ev)
 					CV_SetValue(&cv_chasecam2, cv_chasecam2.value ? 0 : 1);
 				}
 			}
+			if (ev->data1 == gamecontrol[gc_systemmenu][0]
+				|| ev->data1 == gamecontrol[gc_systemmenu][1])
+			{
+				M_OpenEscapeMenu();
+				return true;
+			}
 			return true;
 
 		case ev_keyup:
@@ -1869,7 +1875,6 @@ boolean G_Responder(event_t *ev)
 
 		case ev_joystick2:
 			return true; // eat events
-
 
 		default:
 			break;

--- a/src/g_input.c
+++ b/src/g_input.c
@@ -140,6 +140,8 @@ void G_MapEventsToControls(event_t *ev)
 	{
 		flag = G_CheckDoubleClick(gamekeydown[KEY_JOY1+i], &joydclicks[i]);
 		gamekeydown[KEY_DBLJOY1+i] = flag;
+		if (flag == '\x1') // Improves dodginess of double-press on joysticks..
+			ev->data1 = KEY_DBLJOY1 + i;
 	}
 
 	for (i = 0; i < MOUSEBUTTONS; i++)
@@ -152,6 +154,8 @@ void G_MapEventsToControls(event_t *ev)
 	{
 		flag = G_CheckDoubleClick(gamekeydown[KEY_2JOY1+i], &joy2dclicks[i]);
 		gamekeydown[KEY_DBL2JOY1+i] = flag;
+		if (flag == '\x1') // Improves dodginess of double-press on joysticks..
+			ev->data1 = KEY_DBL2JOY1 + i;
 	}
 }
 

--- a/src/g_input.c
+++ b/src/g_input.c
@@ -990,6 +990,7 @@ static const char *gamecontrolname[num_gamecontrols] =
 	"jump",
 	"console",
 	"pause",
+	"systemmenu",
 	"custom1",
 	"custom2",
 	"custom3",

--- a/src/g_input.h
+++ b/src/g_input.h
@@ -118,6 +118,7 @@ typedef enum
 	gc_jump,
 	gc_console,
 	gc_pause,
+	gc_systemmenu,
 	gc_custom1, // Lua scriptable
 	gc_custom2, // Lua scriptable
 	gc_custom3, // Lua scriptable

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -2100,6 +2100,9 @@ boolean M_Responder(event_t *ev)
 			case KEY_JOY1 + 3:
 				ch = 'n';
 				break;
+			case KEY_JOY1 + 6:
+				ch = KEY_ESCAPE;
+				break;
 			case KEY_MOUSE1 + 1:
 			case KEY_JOY1 + 1:
 				ch = KEY_BACKSPACE;
@@ -2178,7 +2181,8 @@ boolean M_Responder(event_t *ev)
 
 	if (ch == -1)
 		return false;
-	else if (ch == gamecontrol[gc_systemmenu][0]) // allow remappable ESC key
+	else if (ch == gamecontrol[gc_systemmenu][0]
+		|| ch == gamecontrol[gc_systemmenu][1]) // allow remappable ESC key
 		ch = KEY_ESCAPE;
 
 	// F-Keys
@@ -2247,13 +2251,7 @@ boolean M_Responder(event_t *ev)
 			// Spymode on F12 handled in game logic
 
 			case KEY_ESCAPE: // Pop up menu
-				if (chat_on)
-				{
-					HU_clearChatChars();
-					chat_on = false;
-				}
-				else
-					M_StartControlPanel();
+				M_OpenEscapeMenu();
 				return true;
 		}
 		noFurtherInput = false; // turns out we didn't care
@@ -2439,6 +2437,21 @@ boolean M_Responder(event_t *ev)
 	}
 
 	return true;
+}
+
+//
+// M_OpenEscapeMenu
+// Opens the escape menu or exits the chat, depending on game state.
+//
+void M_OpenEscapeMenu(void)
+{
+	if (chat_on)
+	{
+		HU_clearChatChars();
+		chat_on = false;
+	}
+	else
+		M_StartControlPanel();
 }
 
 //

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -1077,6 +1077,8 @@ static menuitem_t OP_MiscControlsMenu[] =
 	{IT_CALL | IT_STRING2, NULL, "Custom Action 2",  M_ChangeControl, gc_custom2      },
 	{IT_CALL | IT_STRING2, NULL, "Custom Action 3",  M_ChangeControl, gc_custom3      },
 
+	{IT_CALL | IT_STRING2, NULL, "System Menu (ESC)",M_ChangeControl, gc_systemmenu   },
+
 	{IT_CALL | IT_STRING2, NULL, "Pause",            M_ChangeControl, gc_pause        },
 	{IT_CALL | IT_STRING2, NULL, "Console",          M_ChangeControl, gc_console      },
 };
@@ -2176,11 +2178,14 @@ boolean M_Responder(event_t *ev)
 
 	if (ch == -1)
 		return false;
+	else if (ch == gamecontrol[gc_systemmenu][0]) // allow remappable ESC key
+		ch = KEY_ESCAPE;
 
 	// F-Keys
 	if (!menuactive)
 	{
 		noFurtherInput = true;
+
 		switch (ch)
 		{
 			case KEY_F1: // Help key

--- a/src/m_menu.h
+++ b/src/m_menu.h
@@ -42,6 +42,10 @@ void M_Init(void);
 // does nothing if menu is already up.
 void M_StartControlPanel(void);
 
+// Calls M_StartControlPanel if chat is not open,
+// otherwise, closes chat.
+void M_OpenEscapeMenu(void);
+
 // Called upon end of a mode attack run
 void M_EndModeAttackRun(void);
 
@@ -68,7 +72,6 @@ void M_QuitResponse(INT32 ch);
 
 // Determines whether to show a level in the list
 boolean M_CanShowLevelInList(INT32 mapnum, INT32 gt);
-
 
 // flags for items in the menu
 // menu handle (what we do when key is pressed


### PR DESCRIPTION
Interprets input key as gc_systemmenu and changes it to KEY_ESCAPE.
Also partially fixes a bug with double joystick button presses. There seems to be an issue where they don't go through 100% of the time (EG: I double press A to jump, and it the jump only comes out occasionally).. 
this *improves* the issue, but doesn't fix it 100%.