### PR TITLE
Smoother MD2 interpolation

### DIFF
--- a/src/hardware/hw_md2.c
+++ b/src/hardware/hw_md2.c
@@ -1347,7 +1347,7 @@ void HWR_DrawMD2(gr_vissprite_t *spr)
 		frame = (spr->mobj->frame & FF_FRAMEMASK) % md2->model->header.numFrames;
 		buff = md2->model->glCommandBuffer;
 		curr = &md2->model->frames[frame];
-		if (cv_grmd2.value == 1)
+		if (cv_grmd2.value == 1 && tics <= durs)
 		{
 			// frames are handled differently for states with FF_ANIMATE, so get the next frame differently for the interpolation
 			if (spr->mobj->frame & FF_ANIMATE)


### PR DESCRIPTION
Originally fixed by toaster. Fixes a case where animations can end up being jerky(like FSonic's Super Sonic walk animations) In her own words[:"The jerkiness was caused by treating all calculations as if interpoleration should be within the bounds, whilst not actually doing anything to limit it to that"](https://mb.srb2.org/showpost.php?p=798298&postcount=69) Should be safe to merge to master.

