### PR TITLE
Fix net commands not always being freed

### DIFF
--- a/src/d_clisrv.c
+++ b/src/d_clisrv.c
@@ -3984,7 +3984,8 @@ FILESTAMP
 						INT32 k = *txtpak++; // playernum
 						const size_t txtsize = txtpak[0]+1;
 
-						M_Memcpy(D_GetTextcmd(i, k), txtpak, txtsize);
+						if (i >= gametic) // Don't copy old net commands
+							M_Memcpy(D_GetTextcmd(i, k), txtpak, txtsize);
 						txtpak += txtsize;
 					}
 				}


### PR DESCRIPTION
If a PT_SERVERTICS packet contains net commands already executed, do not allocate them again, as they would never be freed afterward.
Note that along with wasting memory, not freeing net commands could also continuously decrease performance as you stayed on a server, because the game often needs to iterate through the net command list, which would grow more and grow with time.