### PR TITLE
Don't init the sound system on dedicated servers

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1223,7 +1223,13 @@ void D_SRB2Main(void)
 	CONS_Printf("R_Init(): Init SRB2 refresh daemon.\n");
 	R_Init();
 
-	// setting up sound
+	// setting up sound	
+	if (dedicated)
+	{
+		nosound = true;
+		nomidimusic = nodigimusic = true;
+	}
+	else
 	CONS_Printf("S_Init(): Setting up sound.\n");
 	if (M_CheckParm("-nosound"))
 		nosound = true;
@@ -1239,7 +1245,7 @@ void D_SRB2Main(void)
 	I_StartupSound();
 	I_InitMusic();
 	S_Init(cv_soundvolume.value, cv_digmusicvolume.value, cv_midimusicvolume.value);
-
+	
 	CONS_Printf("ST_Init(): Init status bar.\n");
 	ST_Init();
 

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1230,7 +1230,9 @@ void D_SRB2Main(void)
 		nomidimusic = nodigimusic = true;
 	}
 	else
-	CONS_Printf("S_Init(): Setting up sound.\n");
+	{
+		CONS_Printf("S_Init(): Setting up sound.\n");
+	}
 	if (M_CheckParm("-nosound"))
 		nosound = true;
 	if (M_CheckParm("-nomusic")) // combines -nomidimusic and -nodigmusic
@@ -1245,7 +1247,7 @@ void D_SRB2Main(void)
 	I_StartupSound();
 	I_InitMusic();
 	S_Init(cv_soundvolume.value, cv_digmusicvolume.value, cv_midimusicvolume.value);
-	
+
 	CONS_Printf("ST_Init(): Init status bar.\n");
 	ST_Init();
 

--- a/src/sdl/sdl_sound.c
+++ b/src/sdl/sdl_sound.c
@@ -1180,12 +1180,6 @@ void I_StartupSound(void)
 	audio.callback = I_UpdateStream;
 	audio.userdata = &localdata;
 
-	if (dedicated)
-	{
-		nosound = nomidimusic = nodigimusic = true;
-		return;
-	}
-
 	// Configure sound device
 	CONS_Printf("I_StartupSound:\n");
 
@@ -1480,9 +1474,6 @@ void I_InitMusic(void)
 #ifdef HAVE_LIBGME
 	I_AddExitFunc(I_ShutdownGMEMusic);
 #endif
-
-	if ((nomidimusic && nodigimusic) || dedicated)
-		return;
 
 #ifdef HAVE_MIXER
 	MIX_VERSION(&MIXcompiled)


### PR DESCRIPTION
Apprently on dedicated servers, SRB2 will still init the sound system, wasting memory by caching the level music into RAM. There is also a very low chance the level music could play for a split second as soon the dedicated server is up.