### PR TITLE
SOC sanitizing

### DIFF
--- a/src/dehacked.c
+++ b/src/dehacked.c
@@ -1860,7 +1860,6 @@ static void readframe(MYFILE *f, INT32 num)
 	char *word1;
 	char *word2 = NULL;
 	char *tmp;
-	INT32 j;
 
 	do
 	{
@@ -1874,16 +1873,6 @@ static void readframe(MYFILE *f, INT32 num)
 				*tmp = '\0';
 			if (s == tmp)
 				continue; // Skip comment lines, but don't break.
-
-			for (j = 0; s[j] != '\n'; j++)
-			{
-				if (s[j] == '=')
-				{
-					j += 2;
-					j = atoi(&s[j]);
-					break;
-				}
-			}
 
 			word1 = strtok(s, " ");
 			if (word1)


### PR DESCRIPTION
Hopefully fixes the crash reported in this post here: [Crash Reports (SIGSEGVs, etc) #132
](https://mb.srb2.org/showthread.php?p=799012#post799012)
The crash occurred because of the game iterating over a line of text from a "Frame" aka "State" SOC block for seemingly no purpose whatsoever: if it had no '=' or a new line char on the end (such as when you set the Action for a state), it presumably then went outside the buffer thus causing access violations. Fun.