### PR TITLE
Download filename trunc fix

### DIFF
--- a/src/d_clisrv.c
+++ b/src/d_clisrv.c
@@ -1157,7 +1157,7 @@ static inline void CL_DrawConnectionStatus(void)
 		if (lastfilenum != -1)
 		{
 			INT32 dldlength;
-			static char tempname[32];
+			static char tempname[28];
 			fileneeded_t *file = &fileneeded[lastfilenum];
 			char *filename = file->filename;
 
@@ -1172,16 +1172,16 @@ static inline void CL_DrawConnectionStatus(void)
 			// offset filename to just the name only part
 			filename += strlen(filename) - nameonlylength(filename);
 
-			if (strlen(filename) > 31) // too long to display fully
+			if (strlen(filename) > sizeof(tempname)-1) // too long to display fully
 			{
-				size_t endhalfpos = strlen(filename)-12;
-				// display as first 16 chars + ... + last 12 chars
-				// which should add up to 31 if our math(s) is correct
-				snprintf(tempname, 31, "%.16s...%.12s", filename, filename+endhalfpos);
+				size_t endhalfpos = strlen(filename)-10;
+				// display as first 14 chars + ... + last 10 chars
+				// which should add up to 27 if our math(s) is correct
+				snprintf(tempname, sizeof(tempname), "%.14s...%.10s", filename, filename+endhalfpos);
 			}
 			else // we can copy the whole thing in safely
 			{
-				strncpy(tempname, filename, 31);
+				strncpy(tempname, filename, sizeof(tempname)-1);
 			}
 
 			V_DrawCenteredString(BASEVIDWIDTH/2, BASEVIDHEIGHT-24-32, V_YELLOWMAP,

--- a/src/d_clisrv.c
+++ b/src/d_clisrv.c
@@ -1158,21 +1158,38 @@ static inline void CL_DrawConnectionStatus(void)
 		{
 			INT32 dldlength;
 			static char tempname[32];
+			fileneeded_t *file = &fileneeded[lastfilenum];
+			char *filename = file->filename;
 
 			Net_GetNetStat();
-			dldlength = (INT32)((fileneeded[lastfilenum].currentsize/(double)fileneeded[lastfilenum].totalsize) * 256);
+			dldlength = (INT32)((file->currentsize/(double)file->totalsize) * 256);
 			if (dldlength > 256)
 				dldlength = 256;
 			V_DrawFill(BASEVIDWIDTH/2-128, BASEVIDHEIGHT-24, 256, 8, 175);
 			V_DrawFill(BASEVIDWIDTH/2-128, BASEVIDHEIGHT-24, dldlength, 8, 160);
 
 			memset(tempname, 0, sizeof(tempname));
-			nameonly(strncpy(tempname, fileneeded[lastfilenum].filename, 31));
+			// offset filename to just the name only part
+			filename += strlen(filename) - nameonlylength(filename);
+
+			if (strlen(filename) > 31) // too long to display fully
+			{
+				size_t endhalfpos = strlen(filename)-12;
+				// display as first 16 chars + ... + last 12 chars
+				// which should add up to 31 if our math(s) is correct
+				strncpy(tempname, filename, 16);
+				strncpy(tempname+16, "...", 3);
+				strncpy(tempname+16+3, filename+endhalfpos, 12);
+			}
+			else // we can copy the whole thing in safely
+			{
+				strncpy(tempname, filename, 31);
+			}
 
 			V_DrawCenteredString(BASEVIDWIDTH/2, BASEVIDHEIGHT-24-32, V_YELLOWMAP,
 				va(M_GetText("Downloading \"%s\""), tempname));
 			V_DrawString(BASEVIDWIDTH/2-128, BASEVIDHEIGHT-24, V_20TRANS|V_MONOSPACE,
-				va(" %4uK/%4uK",fileneeded[lastfilenum].currentsize>>10,fileneeded[lastfilenum].totalsize>>10));
+				va(" %4uK/%4uK",fileneeded[lastfilenum].currentsize>>10,file->totalsize>>10));
 			V_DrawRightAlignedString(BASEVIDWIDTH/2+128, BASEVIDHEIGHT-24, V_20TRANS|V_MONOSPACE,
 				va("%3.1fK/s ", ((double)getbps)/1024));
 		}

--- a/src/d_clisrv.c
+++ b/src/d_clisrv.c
@@ -1177,9 +1177,7 @@ static inline void CL_DrawConnectionStatus(void)
 				size_t endhalfpos = strlen(filename)-12;
 				// display as first 16 chars + ... + last 12 chars
 				// which should add up to 31 if our math(s) is correct
-				strncpy(tempname, filename, 16);
-				strncpy(tempname+16, "...", 3);
-				strncpy(tempname+16+3, filename+endhalfpos, 12);
+				snprintf(tempname, 31, "%.16s...%.12s", filename, filename+endhalfpos);
 			}
 			else // we can copy the whole thing in safely
 			{


### PR DESCRIPTION
Fixes [SRB2MB: [Linux]Filename is truncated on download screen](https://mb.srb2.org/showthread.php?t=42904). Turns out the full path name (with DOWNLOAD/ or [home]/DOWNLOAD/) was being truncated, THEN what's left of the actual file name in the truncated name was used of that. That's just silly, all we need to care about is the actual file name itself.

I also improved the behaviour for extremely long filenames (even without the path) - ellipsis is now used in the middle to shorten the name, as seen below:

![Example gif](https://cdn.discordapp.com/attachments/357946927477948417/420683884104253440/srb20006.gif)

(the full name was abcdefghijklmnopqrstuvwxyz1234567890.wad, just so you know :) )