### PR TITLE
Software - Fake contrast fix

### DIFF
--- a/src/r_segs.c
+++ b/src/r_segs.c
@@ -408,10 +408,17 @@ void R_RenderMaskedSegRange(drawseg_t *ds, INT32 x1, INT32 x2)
 
 			if (rlight->extra_colormap && rlight->extra_colormap->fog)
 				;
-			else if (curline->v1->y == curline->v2->y)
-				lightnum--;
-			else if (curline->v1->x == curline->v2->x)
-				lightnum++;
+			else
+			{
+				fixed_t extralight = -(1<<FRACBITS) +
+				FixedDiv(AngleFixed(R_PointToAngle2(0, 0,
+					abs(curline->v1->y - curline->v2->y),
+					abs(curline->v1->x - curline->v2->x))), 90<<FRACBITS)
+				* 2;
+				extralight = FixedFloor(extralight + (FRACUNIT>>1))>>FRACBITS;
+
+				lightnum += extralight;
+			}
 
 			rlight->lightnum = lightnum;
 		}
@@ -431,10 +438,17 @@ void R_RenderMaskedSegRange(drawseg_t *ds, INT32 x1, INT32 x2)
 		if (colfunc == R_DrawFogColumn_8
 			|| (frontsector->extra_colormap && frontsector->extra_colormap->fog))
 			;
-		else if (curline->v1->y == curline->v2->y)
-			lightnum--;
-		else if (curline->v1->x == curline->v2->x)
-			lightnum++;
+		else
+		{
+			fixed_t extralight = -(1<<FRACBITS) +
+			FixedDiv(AngleFixed(R_PointToAngle2(0, 0,
+				abs(curline->v1->y - curline->v2->y),
+				abs(curline->v1->x - curline->v2->x))), 90<<FRACBITS)
+			* 2;
+			extralight = FixedFloor(extralight + (FRACUNIT>>1))>>FRACBITS;
+
+			lightnum += extralight;
+		}
 
 		if (lightnum < 0)
 			walllights = scalelight[0];
@@ -923,10 +937,17 @@ void R_RenderThickSideRange(drawseg_t *ds, INT32 x1, INT32 x2, ffloor_t *pfloor)
 
 			if (pfloor->flags & FF_FOG || rlight->flags & FF_FOG || (rlight->extra_colormap && rlight->extra_colormap->fog))
 				;
-			else if (curline->v1->y == curline->v2->y)
-				rlight->lightnum--;
-			else if (curline->v1->x == curline->v2->x)
-				rlight->lightnum++;
+			else
+			{
+				fixed_t extralight = -(1<<FRACBITS) +
+				FixedDiv(AngleFixed(R_PointToAngle2(0, 0,
+					abs(curline->v1->y - curline->v2->y),
+					abs(curline->v1->x - curline->v2->x))), 90<<FRACBITS)
+				* 2;
+				extralight = FixedFloor(extralight + (FRACUNIT>>1))>>FRACBITS;
+
+				lightnum += extralight;
+			}
 
 			p++;
 		}
@@ -946,11 +967,21 @@ void R_RenderThickSideRange(drawseg_t *ds, INT32 x1, INT32 x2, ffloor_t *pfloor)
 			lightnum = R_FakeFlat(frontsector, &tempsec, &templight, &templight, false)
 				->lightlevel >> LIGHTSEGSHIFT;
 
-		if (pfloor->flags & FF_FOG || (frontsector->extra_colormap && frontsector->extra_colormap->fog));
-			else if (curline->v1->y == curline->v2->y)
-		lightnum--;
-		else if (curline->v1->x == curline->v2->x)
-			lightnum++;
+
+
+		if (pfloor->flags & FF_FOG || (frontsector->extra_colormap && frontsector->extra_colormap->fog))
+			;
+		else
+		{
+			fixed_t extralight = -(1<<FRACBITS) +
+			FixedDiv(AngleFixed(R_PointToAngle2(0, 0,
+				abs(curline->v1->y - curline->v2->y),
+				abs(curline->v1->x - curline->v2->x))), 90<<FRACBITS)
+			* 2;
+			extralight = FixedFloor(extralight + (FRACUNIT>>1))>>FRACBITS;
+
+			lightnum += extralight;
+		}
 
 		if (lightnum < 0)
 			walllights = scalelight[0];
@@ -1442,10 +1473,17 @@ static void R_RenderSegLoop (void)
 
 				if (dc_lightlist[i].extra_colormap)
 					;
-				else if (curline->v1->y == curline->v2->y)
-					lightnum--;
-				else if (curline->v1->x == curline->v2->x)
-					lightnum++;
+				else
+				{
+					fixed_t extralight = -(1<<FRACBITS) +
+					FixedDiv(AngleFixed(R_PointToAngle2(0, 0,
+						abs(curline->v1->y - curline->v2->y),
+						abs(curline->v1->x - curline->v2->x))), 90<<FRACBITS)
+					* 2;
+					extralight = FixedFloor(extralight + (FRACUNIT>>1))>>FRACBITS;
+
+					lightnum += extralight;
+				}
 
 				if (lightnum < 0)
 					xwalllights = scalelight[0];
@@ -2568,10 +2606,15 @@ void R_StoreWallRange(INT32 start, INT32 stop)
 		// OPTIMIZE: get rid of LIGHTSEGSHIFT globally
 		lightnum = (frontsector->lightlevel >> LIGHTSEGSHIFT);
 
-		if (curline->v1->y == curline->v2->y)
-			lightnum--;
-		else if (curline->v1->x == curline->v2->x)
-			lightnum++;
+		fixed_t extralight = -(1<<FRACBITS) +
+		FixedDiv(AngleFixed(R_PointToAngle2(0, 0,
+			abs(curline->v1->y - curline->v2->y),
+			abs(curline->v1->x - curline->v2->x))), 90<<FRACBITS)
+		* 2;
+
+		extralight = FixedFloor(extralight + (FRACUNIT>>1))>>FRACBITS;
+
+		lightnum += extralight;
 
 		if (lightnum < 0)
 			walllights = scalelight[0];

--- a/src/r_segs.c
+++ b/src/r_segs.c
@@ -412,8 +412,8 @@ void R_RenderMaskedSegRange(drawseg_t *ds, INT32 x1, INT32 x2)
 			{
 				fixed_t extralight = -(1<<FRACBITS) +
 				FixedDiv(AngleFixed(R_PointToAngle2(0, 0,
-					abs(curline->v1->y - curline->v2->y),
-					abs(curline->v1->x - curline->v2->x))), 90<<FRACBITS)
+					abs(curline->v1->x - curline->v2->x),
+					abs(curline->v1->y - curline->v2->y))), 90<<FRACBITS)
 				* 2;
 				extralight = FixedFloor(extralight + (FRACUNIT>>1))>>FRACBITS;
 
@@ -442,8 +442,8 @@ void R_RenderMaskedSegRange(drawseg_t *ds, INT32 x1, INT32 x2)
 		{
 			fixed_t extralight = -(1<<FRACBITS) +
 			FixedDiv(AngleFixed(R_PointToAngle2(0, 0,
-				abs(curline->v1->y - curline->v2->y),
-				abs(curline->v1->x - curline->v2->x))), 90<<FRACBITS)
+				abs(curline->v1->x - curline->v2->x),
+				abs(curline->v1->y - curline->v2->y))), 90<<FRACBITS)
 			* 2;
 			extralight = FixedFloor(extralight + (FRACUNIT>>1))>>FRACBITS;
 
@@ -941,8 +941,8 @@ void R_RenderThickSideRange(drawseg_t *ds, INT32 x1, INT32 x2, ffloor_t *pfloor)
 			{
 				fixed_t extralight = -(1<<FRACBITS) +
 				FixedDiv(AngleFixed(R_PointToAngle2(0, 0,
-					abs(curline->v1->y - curline->v2->y),
-					abs(curline->v1->x - curline->v2->x))), 90<<FRACBITS)
+					abs(curline->v1->x - curline->v2->x),
+					abs(curline->v1->y - curline->v2->y))), 90<<FRACBITS)
 				* 2;
 				extralight = FixedFloor(extralight + (FRACUNIT>>1))>>FRACBITS;
 
@@ -1477,8 +1477,8 @@ static void R_RenderSegLoop (void)
 				{
 					fixed_t extralight = -(1<<FRACBITS) +
 					FixedDiv(AngleFixed(R_PointToAngle2(0, 0,
-						abs(curline->v1->y - curline->v2->y),
-						abs(curline->v1->x - curline->v2->x))), 90<<FRACBITS)
+						abs(curline->v1->x - curline->v2->x),
+						abs(curline->v1->y - curline->v2->y))), 90<<FRACBITS)
 					* 2;
 					extralight = FixedFloor(extralight + (FRACUNIT>>1))>>FRACBITS;
 
@@ -2581,6 +2581,8 @@ void R_StoreWallRange(INT32 start, INT32 stop)
 
 	if (segtextured)
 	{
+		fixed_t extralight;
+
 		offsetangle = rw_normalangle-rw_angle1;
 
 		if (offsetangle > ANGLE_180)
@@ -2606,10 +2608,10 @@ void R_StoreWallRange(INT32 start, INT32 stop)
 		// OPTIMIZE: get rid of LIGHTSEGSHIFT globally
 		lightnum = (frontsector->lightlevel >> LIGHTSEGSHIFT);
 
-		fixed_t extralight = -(1<<FRACBITS) +
+		extralight = -(1<<FRACBITS) +
 		FixedDiv(AngleFixed(R_PointToAngle2(0, 0,
-			abs(curline->v1->y - curline->v2->y),
-			abs(curline->v1->x - curline->v2->x))), 90<<FRACBITS)
+			abs(curline->v1->x - curline->v2->x),
+			abs(curline->v1->y - curline->v2->y))), 90<<FRACBITS)
 		* 2;
 
 		extralight = FixedFloor(extralight + (FRACUNIT>>1))>>FRACBITS;

--- a/src/r_segs.c
+++ b/src/r_segs.c
@@ -946,7 +946,7 @@ void R_RenderThickSideRange(drawseg_t *ds, INT32 x1, INT32 x2, ffloor_t *pfloor)
 				* 2;
 				extralight = FixedFloor(extralight + (FRACUNIT>>1))>>FRACBITS;
 
-				lightnum += extralight;
+				rlight->lightnum += extralight;
 			}
 
 			p++;


### PR DESCRIPTION
Some background: Doom has a simple fake contrast that it applies on walls, but only on walls that are perfectly horizontal or vertical. SRB2 has kept this.

This leads to only very specific walls currently applying this, and when it does apply it can often look very strange in levels because of SRB2 more often using more diagonals for walls.
This fixes the fake contrast so that it's applied to all walls based on their angle (walls facing further to the north/south are 1 light level brighter, walls facing further to the east/west are 1 light level darker, and the more diagonals are not changed).

Unfortunately, this too can present some oddities in levels where it obviously wasn't built for it.
My recommendations are: decide whether you want this always on, or always off (which would require just removing the parts which do the fake contrast) and go with that. Or add an option to choose between on or off on a per level, and per linedef basis for mappers. Either way, this branch shows a way to enable it on all walls if desired.