### PR TITLE
Removed contradictory `-connect` check

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1068,7 +1068,7 @@ void D_SRB2Main(void)
 
 	// add any files specified on the command line with -file wadfile
 	// to the wad list
-	if (!(M_CheckParm("-connect")))
+	if (!(M_CheckParm("-connect") && !M_CheckParm("-server")))
 	{
 		if (M_CheckParm("-file"))
 		{
@@ -1323,7 +1323,7 @@ void D_SRB2Main(void)
 		ultimatemode = true;
 	}
 
-	if (autostart || netgame || M_CheckParm("+connect") || M_CheckParm("-connect"))
+	if (autostart || netgame)
 	{
 		gameaction = ga_nothing;
 
@@ -1361,8 +1361,7 @@ void D_SRB2Main(void)
 			}
 		}
 
-		if (server && !M_CheckParm("+map") && !M_CheckParm("+connect")
-			&& !M_CheckParm("-connect"))
+		if (server && !M_CheckParm("+map"))
 		{
 			// Prevent warping to nonexistent levels
 			if (W_CheckNumForName(G_BuildMapName(pstartmap)) == LUMPERROR)


### PR DESCRIPTION
This fixes a bug discovered by Steel Titanium, in which passing both `-server` and `-connect` will cause the game to hang on the startup screen.  This is due to the fact that `-server` takes precedence over `-connect`, but cannot preform a map change because `-connect` is one of the parameters.