### PR TITLE
Dedicated debug hotfix

### DIFF
--- a/src/g_game.c
+++ b/src/g_game.c
@@ -3588,7 +3588,8 @@ void G_InitNew(UINT8 pultmode, const char *mapname, boolean resetplayer, boolean
 		unlocktriggers = 0;
 
 		// clear itemfinder, just in case
-		CV_StealthSetValue(&cv_itemfinder, 0);
+		if (!dedicated) // except in dedicated servers, where it is not registered and can actually I_Error debug builds
+			CV_StealthSetValue(&cv_itemfinder, 0);
 	}
 
 	// internal game map


### PR DESCRIPTION
This should fix the game I_Error-ing on attempting to run the game in dedicated mode with debug builds of SRB2. Thanks to @SteelTitanium for alerting me this was an issue at all.

Since cv_itemfinder only affects things locally we can assume it's safe for master (unless I'm mistaken).