### PR TITLE
Don't increment totalplaytime if a demo is playing.

### DIFF
--- a/src/p_tick.c
+++ b/src/p_tick.c
@@ -607,6 +607,7 @@ void P_Ticker(boolean run)
 	}
 
 	// Keep track of how long they've been playing!
+	if (!demoplayback) // Don't incerment if a demo is playing.
 	totalplaytime++;
 
 	if (!useNightsSS && G_IsSpecialStage(gamemap))

--- a/src/p_tick.c
+++ b/src/p_tick.c
@@ -608,7 +608,7 @@ void P_Ticker(boolean run)
 
 	// Keep track of how long they've been playing!
 	if (!demoplayback) // Don't incerment if a demo is playing.
-	totalplaytime++;
+		totalplaytime++;
 
 	if (!useNightsSS && G_IsSpecialStage(gamemap))
 		P_DoSpecialStageStuff();

--- a/src/p_tick.c
+++ b/src/p_tick.c
@@ -607,7 +607,7 @@ void P_Ticker(boolean run)
 	}
 
 	// Keep track of how long they've been playing!
-	if (!demoplayback) // Don't incerment if a demo is playing.
+	if (!demoplayback) // Don't increment if a demo is playing.
 		totalplaytime++;
 
 	if (!useNightsSS && G_IsSpecialStage(gamemap))


### PR DESCRIPTION
s issue reported by Kitoko on Discord where the total playtime would be counted during a demo playback, also effects record attack replays.