### PR TITLE
More helpful error messages

### DIFF
--- a/src/hardware/hw_md2.c
+++ b/src/hardware/hw_md2.c
@@ -799,7 +799,7 @@ void HWR_InitMD2(void)
 
 	if (!f)
 	{
-		CONS_Printf("%s", M_GetText("Error while loading md2.dat\n"));
+		CONS_Printf("%s %s\n", M_GetText("Error while loading md2.dat:"), strerror(errno));
 		nomd2s = true;
 		return;
 	}

--- a/src/hardware/hw_md2.c
+++ b/src/hardware/hw_md2.c
@@ -67,6 +67,10 @@
  #endif
 #endif
 
+#ifndef errno
+#include "errno.h"
+#endif
+
 #define NUMVERTEXNORMALS 162
 float avertexnormals[NUMVERTEXNORMALS][3] = {
 {-0.525731f, 0.000000f, 0.850651f},


### PR DESCRIPTION
Now when fopen() fails to open md2.dat, it will get the last error and print it to the console, instead of letting the user having to figure out what the error is.