### PR TITLE
m_fixed: asm: cc is not a register

### DIFF
--- a/src/m_fixed.h
+++ b/src/m_fixed.h
@@ -75,7 +75,7 @@ typedef INT32 fixed_t;
 			:"=a" (ret)            // eax is always the result and the first operand (%0,%1)
 			:"0" (a), "r" (b)      // and %2 is what we use imull on with what in %1
 			, "I" (FRACBITS)       // %3 holds FRACBITS (normally 16)
-			:"%cc", "%edx"         // edx and condition codes clobbered
+			:"cc", "%edx"         // edx and condition codes clobbered
 		);
 		return ret;
 	}


### PR DESCRIPTION
gcc accepts

  __asm__ ( "" : : : "%cc");

but not clang:

    error: unknown register name '%cc' in asm
        :"%cc", "%edx"         // edx and condition codes clobbered

'cc' is not a register, thus '%cc' is rightfully not accepted.

Repro: build the project on x86_64 with:
    cmake -H. -Bbuild -DCMAKE_C_COMPILER=clang -DCMAKE_SIZEOF_VOID_P=4 -DCMAKE_C_FLAGS="-m32"