### PR TITLE
F12 fix

### DIFF
--- a/src/sdl/i_video.c
+++ b/src/sdl/i_video.c
@@ -658,6 +658,14 @@ static void Impl_HandleMouseButtonEvent(SDL_MouseButtonEvent evt, Uint32 type)
 
 	SDL_memset(&event, 0, sizeof(event_t));
 
+	// Ignore the event if the mouse is not actually focused on the window.
+	// This can happen if you used the mouse to restore keyboard focus;
+	// this apparently makes a mouse button down event but not a mouse button up event,
+	// resulting in whatever key was pressed down getting "stuck" if we don't ignore it.
+	// -- Monster Iestyn (28/05/18)
+	if (SDL_GetMouseFocus() != window)
+		return;
+
 	/// \todo inputEvent.button.which
 	if (USE_MOUSEINPUT)
 	{


### PR DESCRIPTION
This fixes F12 not working if you clicked on a window's title bar to get back window focus, and you have a player control such as Ring Toss mapped to the left mouse button (which is a game default I believe). Turns out the game basically doesn't realise you let go of said button apparently!

Note: The workaround for 2.1.20 is to either move the mouse inside the window and click again, or press the keyboard button for the control (if you have one set). Obviously this depends on what your controls actually are, use your common sense if necessary please. =)