### PR TITLE
Fix pausing on gme

### DIFF
--- a/src/sdl/mixer_sound.c
+++ b/src/sdl/mixer_sound.c
@@ -475,12 +475,24 @@ void I_ShutdownMusic(void)
 void I_PauseSong(INT32 handle)
 {
 	(void)handle;
+#ifdef HAVE_LIBGME
+	if (gme)
+	{
+		Mix_HookMusic(NULL, NULL);
+	}
+#endif
 	Mix_PauseMusic();
 }
 
 void I_ResumeSong(INT32 handle)
 {
 	(void)handle;
+#ifdef HAVE_LIBGME
+	if (gme)
+	{
+		Mix_HookMusic(mix_gme, gme);
+	}
+#endif
 	Mix_ResumeMusic();
 }
 


### PR DESCRIPTION
Fixes pausing on GME, who knew the fix was really that simple. After testing it, pausing and resuming now works for GME, and formats supported internally by SDL_Mixer.