### PR TITLE
Disable admin password by default

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1051,15 +1051,6 @@ void D_SRB2Main(void)
 
 	if (M_CheckParm("-password") && M_IsNextParm())
 		D_SetPassword(M_GetNextParm());
-	else
-	{
-		size_t z;
-		char junkpw[25];
-		for (z = 0; z < 24; z++)
-			junkpw[z] = (char)(rand() & 64)+32;
-		junkpw[24] = '\0';
-		D_SetPassword(junkpw);
-	}
 
 	// add any files specified on the command line with -file wadfile
 	// to the wad list

--- a/src/d_netcmd.c
+++ b/src/d_netcmd.c
@@ -2656,10 +2656,12 @@ static void D_MD5PasswordPass(const UINT8 *buffer, size_t len, const char *salt,
 
 #define BASESALT "basepasswordstorage"
 static UINT8 adminpassmd5[16];
+static boolean adminpasswordset = false;
 
 void D_SetPassword(const char *pw)
 {
 	D_MD5PasswordPass((const UINT8 *)pw, strlen(pw), BASESALT, &adminpassmd5);
+	adminpasswordset = true;
 }
 
 // Remote Administration
@@ -2727,6 +2729,9 @@ static void Got_Login(UINT8 **cp, INT32 playernum)
 	UINT8 sentmd5[16], finalmd5[16];
 
 	READMEM(*cp, sentmd5, 16);
+
+	if (!adminpasswordset)
+		CONS_Printf(M_GetText("Password from %s failed (no password set).\n"), player_names[playernum]);
 
 	if (client)
 		return;
@@ -3951,7 +3956,7 @@ static void Command_RestartAudio_f(void)
 	I_ShutdownSound();
 	I_StartupSound();
 	I_InitMusic();
-	
+
 // These must be called or no sound and music until manually set.
 
 	I_SetSfxVolume(cv_soundvolume.value);
@@ -3959,7 +3964,7 @@ static void Command_RestartAudio_f(void)
 	I_SetMIDIMusicVolume(cv_midimusicvolume.value);
 	if (Playing()) // Gotta make sure the player is in a level
 		P_RestoreMusic(&players[consoleplayer]);
-	
+
 }
 
 /** Quits a game and returns to the title screen.

--- a/src/d_netcmd.c
+++ b/src/d_netcmd.c
@@ -2731,7 +2731,10 @@ static void Got_Login(UINT8 **cp, INT32 playernum)
 	READMEM(*cp, sentmd5, 16);
 
 	if (!adminpasswordset)
+	{
 		CONS_Printf(M_GetText("Password from %s failed (no password set).\n"), player_names[playernum]);
+		return;
+	}
 
 	if (client)
 		return;


### PR DESCRIPTION
SRB2 sets a random admin password if you don't set one yourself, but since the PRNG seed is initialised using the OS time, the password is extremely easy to figure out.
Who would want a random password anyway.