### PR TITLE
Multiplayer menu playername fix

### DIFF
--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -6543,7 +6543,7 @@ static void M_HandleSetupMultiPlayer(INT32 choice)
 			if (choice < 32 || choice > 127 || itemOn != 0)
 				break;
 			l = strlen(setupm_name);
-			if (l < MAXPLAYERNAME-1)
+			if (l < MAXPLAYERNAME)
 			{
 				S_StartSound(NULL,sfx_menu1); // Tails
 				setupm_name[l] =(char)choice;


### PR DESCRIPTION
Fixes [SRB2MB: Playername max length is different between console/player setup menu](https://mb.srb2.org/showthread.php?t=43519). Turns out the menu was at fault in this case.

This is a merge to master since I'm pretty sure this doesn't affect netplay directly