### PR TITLE
Password fix hotfix

### DIFF
--- a/src/d_netcmd.c
+++ b/src/d_netcmd.c
@@ -2730,14 +2730,14 @@ static void Got_Login(UINT8 **cp, INT32 playernum)
 
 	READMEM(*cp, sentmd5, 16);
 
+	if (client)
+		return;
+
 	if (!adminpasswordset)
 	{
 		CONS_Printf(M_GetText("Password from %s failed (no password set).\n"), player_names[playernum]);
 		return;
 	}
-
-	if (client)
-		return;
 
 	// Do the final pass to compare with the sent md5
 	D_MD5PasswordPass(adminpassmd5, 16, va("PNUM%02d", playernum), &finalmd5);


### PR DESCRIPTION
Hotfix for LJSonic's password security fix: prevent 

> Password from [player name] failed (no password set)

 from being printed in the console for everyone that's not the host if someone tries to use the verify command, regardless of whether a password is actually set or not.