### PR TITLE
More accurate GIF delay

### DIFF
--- a/src/m_anigif.c
+++ b/src/m_anigif.c
@@ -492,7 +492,9 @@ static void GIF_framewrite(void)
 
 	// screen regions are handled in GIF_lzw
 	{
-		UINT16 delay = 3; // todo
+		int d1 = (int)((100.0/NEWTICRATE)*gif_frames);
+		int d2 = (int)((100.0/NEWTICRATE)*(gif_frames-1));
+		UINT16 delay = d1-d2;
 		INT32 startline;
 
 		WRITEMEM(p, gifframe_gchead, 4);

--- a/src/m_anigif.c
+++ b/src/m_anigif.c
@@ -492,8 +492,8 @@ static void GIF_framewrite(void)
 
 	// screen regions are handled in GIF_lzw
 	{
-		int d1 = (int)((100.0/NEWTICRATE)*gif_frames);
-		int d2 = (int)((100.0/NEWTICRATE)*(gif_frames-1));
+		int d1 = (int)((100.0/NEWTICRATE)*gif_frames+1);
+		int d2 = (int)((100.0/NEWTICRATE)*(gif_frames));
 		UINT16 delay = d1-d2;
 		INT32 startline;
 

--- a/src/m_anigif.c
+++ b/src/m_anigif.c
@@ -492,7 +492,7 @@ static void GIF_framewrite(void)
 
 	// screen regions are handled in GIF_lzw
 	{
-		int d1 = (int)((100.0/NEWTICRATE)*gif_frames+1);
+		int d1 = (int)((100.0/NEWTICRATE)*(gif_frames+1));
 		int d2 = (int)((100.0/NEWTICRATE)*(gif_frames));
 		UINT16 delay = d1-d2;
 		INT32 startline;


### PR DESCRIPTION
From [More accurate GIF delay by PrisimaTheFox](https://github.com/STJr/SRB2/pull/284) on GitHub:
```
This change makes the GIF frame delay much more accurate. It was changed from a fixed 3, which caused the GIF to be inaccurate by 1 tic every 7 tics when the TICRATE was 35.
```

I remade the branch on this repo to fix the commit mess on the original. Credit goes to Prisima for doing this obviously