### PR TITLE
Music Code Cleanup

### DIFF
--- a/src/android/i_sound.c
+++ b/src/android/i_sound.c
@@ -92,7 +92,7 @@ boolean I_LoadSong(char *data, size_t len)
         return -1;
 }
 
-void I_SetMIDIMusicVolume(INT32 volume)
+void I_SetMusicVolume(INT32 volume)
 {
         (void)volume;
 }
@@ -119,11 +119,6 @@ void I_UnloadSong(void)
 //
 
 UINT8 digmusic_started = 0;
-
-void I_SetDigMusicVolume(INT32 volume)
-{
-        (void)volume;
-}
 
 boolean I_SetSongSpeed(float speed)
 {

--- a/src/android/i_sound.c
+++ b/src/android/i_sound.c
@@ -65,6 +65,16 @@ musictype_t I_GetMusicType(void)
 	return MU_NONE;
 }
 
+boolean I_MusicPlaying(void)
+{
+	return false;
+}
+
+boolean I_MusicPaused(void)
+{
+	return false;
+}
+
 void I_InitMusic(void){}
 
 void I_ShutdownMusic(void){}

--- a/src/android/i_sound.c
+++ b/src/android/i_sound.c
@@ -55,12 +55,22 @@ void I_SetSfxVolume(INT32 volume)
         (void)volume;
 }
 
-//
-//  MUSIC I/O
-//
-UINT8 music_started = 0;
+/// ------------------------
+//  MUSIC SYSTEM
+/// ------------------------
 
-musictype_t I_GetMusicType(void)
+UINT8 music_started = 0;
+UINT8 digmusic_started = 0;
+
+void I_InitMusic(void){}
+
+void I_ShutdownMusic(void){}
+
+/// ------------------------
+//  MUSIC PROPERTIES
+/// ------------------------
+
+musictype_t I_MusicType(void)
 {
 	return MU_NONE;
 }
@@ -75,23 +85,19 @@ boolean I_MusicPaused(void)
 	return false;
 }
 
-void I_InitMusic(void){}
+/// ------------------------
+//  MUSIC EFFECTS
+/// ------------------------
 
-void I_ShutdownMusic(void){}
-
-void I_PauseSong(void)
+boolean I_SetSongSpeed(float speed)
 {
-        (void)handle;
+        (void)speed;
+        return false;
 }
 
-void I_ResumeSong(void)
-{
-        (void)handle;
-}
-
-//
-//  MIDI I/O
-//
+/// ------------------------
+//  MUSIC PLAYBACK
+/// ------------------------
 
 UINT8 midimusic_started = 0;
 
@@ -102,9 +108,9 @@ boolean I_LoadSong(char *data, size_t len)
         return -1;
 }
 
-void I_SetMusicVolume(INT32 volume)
+void I_UnloadSong()
 {
-        (void)volume;
+
 }
 
 boolean I_PlaySong(boolean looping)
@@ -119,19 +125,17 @@ void I_StopSong(void)
         (void)handle;
 }
 
-void I_UnloadSong(void)
+void I_PauseSong(void)
 {
         (void)handle;
 }
 
-//
-//  DIGMUSIC I/O
-//
-
-UINT8 digmusic_started = 0;
-
-boolean I_SetSongSpeed(float speed)
+void I_ResumeSong(void)
 {
-        (void)speed;
-        return false;
+        (void)handle;
+}
+
+void I_SetMusicVolume(INT32 volume)
+{
+        (void)volume;
 }

--- a/src/android/i_sound.c
+++ b/src/android/i_sound.c
@@ -70,17 +70,17 @@ void I_ShutdownMusic(void){}
 //  MUSIC PROPERTIES
 /// ------------------------
 
-musictype_t I_MusicType(void)
+musictype_t I_SongType(void)
 {
 	return MU_NONE;
 }
 
-boolean I_MusicPlaying(void)
+boolean I_SongPlaying(void)
 {
 	return false;
 }
 
-boolean I_MusicPaused(void)
+boolean I_SongPaused(void)
 {
 	return false;
 }

--- a/src/android/i_sound.c
+++ b/src/android/i_sound.c
@@ -60,6 +60,11 @@ void I_SetSfxVolume(INT32 volume)
 //
 UINT8 music_started = 0;
 
+musictype_t I_GetMusicType(void)
+{
+	return MU_NONE;
+}
+
 void I_InitMusic(void){}
 
 void I_ShutdownMusic(void){}
@@ -99,12 +104,12 @@ boolean I_PlaySong(boolean looping)
         return false;
 }
 
-void I_StopSong(INT32 handle)
+void I_StopSong(void)
 {
         (void)handle;
 }
 
-void I_UnRegisterSong(INT32 handle)
+void I_UnloadSong(void)
 {
         (void)handle;
 }
@@ -114,19 +119,6 @@ void I_UnRegisterSong(INT32 handle)
 //
 
 UINT8 digmusic_started = 0;
-
-void I_InitDigMusic(void){}
-
-void I_ShutdownDigMusic(void){}
-
-boolean I_StartDigSong(const char *musicname, INT32 looping)
-{
-        (void)musicname;
-        (void)looping;
-        return false;
-}
-
-void I_StopDigSong(void){}
 
 void I_SetDigMusicVolume(INT32 volume)
 {

--- a/src/android/i_sound.c
+++ b/src/android/i_sound.c
@@ -64,12 +64,12 @@ void I_InitMusic(void){}
 
 void I_ShutdownMusic(void){}
 
-void I_PauseSong(INT32 handle)
+void I_PauseSong(void)
 {
         (void)handle;
 }
 
-void I_ResumeSong(INT32 handle)
+void I_ResumeSong(void)
 {
         (void)handle;
 }
@@ -80,23 +80,19 @@ void I_ResumeSong(INT32 handle)
 
 UINT8 midimusic_started = 0;
 
-void I_InitMIDIMusic(void){}
-
-void I_ShutdownMIDIMusic(void){}
-
-void I_SetMIDIMusicVolume(INT32 volume)
-{
-        (void)volume;
-}
-
-INT32 I_RegisterSong(void *data, size_t len)
+boolean I_LoadSong(char *data, size_t len)
 {
         (void)data;
         (void)len;
         return -1;
 }
 
-boolean I_PlaySong(INT32 handle, INT32 looping)
+void I_SetMIDIMusicVolume(INT32 volume)
+{
+        (void)volume;
+}
+
+boolean I_PlaySong(boolean looping)
 {
         (void)handle;
         (void)looping;

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -121,20 +121,17 @@ INT32 postimgparam;
 postimg_t postimgtype2 = postimg_none;
 INT32 postimgparam2;
 
+// These variables are only true if
+// whether the respective sound system is disabled
+// or they're init'ed, but the player just toggled them
 #ifdef _XBOX
 boolean midi_disabled = true, sound_disabled = true;
 boolean digital_disabled = true;
 #else
-boolean midi_disabled = false, sound_disabled = false;
-boolean digital_disabled = false; // No fmod-based music
-#endif
-
-// These variables are only true if
-// whether the respective sound system is disabled
-// or they're init'ed, but the player just toggled them
 boolean midi_disabled = false;
 boolean sound_disabled = false;
 boolean digital_disabled = false;
+#endif
 
 boolean advancedemo;
 #ifdef DEBUGFILE

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1217,7 +1217,7 @@ void D_SRB2Main(void)
 	}
 	else
 	{
-		CONS_Printf("S_Init(): Setting up sound.\n");
+		CONS_Printf("S_InitSfxChannels(): Setting up sound channels.\n");
 	}
 	if (M_CheckParm("-nosound"))
 		nosound = true;
@@ -1232,7 +1232,7 @@ void D_SRB2Main(void)
 	}
 	I_StartupSound();
 	I_InitMusic();
-	S_Init(cv_soundvolume.value, cv_digmusicvolume.value, cv_midimusicvolume.value);
+	S_InitSfxChannels(cv_soundvolume.value);
 
 	CONS_Printf("ST_Init(): Init status bar.\n");
 	ST_Init();

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -122,17 +122,17 @@ postimg_t postimgtype2 = postimg_none;
 INT32 postimgparam2;
 
 #ifdef _XBOX
-boolean nomidimusic = true, nosound = true;
-boolean nodigimusic = true;
+boolean midi_disabled = true, sound_disabled = true;
+boolean digital_disabled = true;
 #else
-boolean nomidimusic = false, nosound = false;
-boolean nodigimusic = false; // No fmod-based music
+boolean midi_disabled = false, sound_disabled = false;
+boolean digital_disabled = false; // No fmod-based music
 #endif
 
 // These variables are only true if
-// the respective sound system is initialized
-// and active, but no sounds/music should play.
-boolean music_disabled = false;
+// whether the respective sound system is disabled
+// or they're init'ed, but the player just toggled them
+boolean midi_disabled = false;
 boolean sound_disabled = false;
 boolean digital_disabled = false;
 
@@ -1212,23 +1212,23 @@ void D_SRB2Main(void)
 	// setting up sound
 	if (dedicated)
 	{
-		nosound = true;
-		nomidimusic = nodigimusic = true;
+		sound_disabled = true;
+		midi_disabled = digital_disabled = true;
 	}
 	else
 	{
 		CONS_Printf("S_InitSfxChannels(): Setting up sound channels.\n");
 	}
 	if (M_CheckParm("-nosound"))
-		nosound = true;
+		sound_disabled = true;
 	if (M_CheckParm("-nomusic")) // combines -nomidimusic and -nodigmusic
-		nomidimusic = nodigimusic = true;
+		midi_disabled = digital_disabled = true;
 	else
 	{
 		if (M_CheckParm("-nomidimusic"))
-			nomidimusic = true; ; // WARNING: DOS version initmusic in I_StartupSound
+			midi_disabled = true; ; // WARNING: DOS version initmusic in I_StartupSound
 		if (M_CheckParm("-nodigmusic"))
-			nodigimusic = true; // WARNING: DOS version initmusic in I_StartupSound
+			digital_disabled = true; // WARNING: DOS version initmusic in I_StartupSound
 	}
 	I_StartupSound();
 	I_InitMusic();

--- a/src/d_netcmd.c
+++ b/src/d_netcmd.c
@@ -3963,11 +3963,9 @@ static void Command_RestartAudio_f(void)
 // These must be called or no sound and music until manually set.
 
 	I_SetSfxVolume(cv_soundvolume.value);
-	I_SetDigMusicVolume(cv_digmusicvolume.value);
-	I_SetMIDIMusicVolume(cv_midimusicvolume.value);
+	S_SetMusicVolume(cv_digmusicvolume.value, cv_midimusicvolume.value);
 	if (Playing()) // Gotta make sure the player is in a level
 		P_RestoreMusic(&players[consoleplayer]);
-
 }
 
 /** Quits a game and returns to the title screen.

--- a/src/d_netcmd.c
+++ b/src/d_netcmd.c
@@ -3955,6 +3955,7 @@ static void Command_RestartAudio_f(void)
 		return;
 
 	S_StopMusic();
+	S_StopSounds();
 	I_ShutdownMusic();
 	I_ShutdownSound();
 	I_StartupSound();

--- a/src/djgppdos/i_sound.c
+++ b/src/djgppdos/i_sound.c
@@ -140,15 +140,6 @@ void I_SetSfxVolume(INT32 volume)
 	set_volume (Volset(volume),-1);
 }
 
-void I_SetMusicVolume(INT32 volume)
-{
-	if (midi_disabled)
-		return;
-
-	// Now set volume on output device.
-	set_volume (-1, Volset(volume));
-}
-
 //
 // Starting a sound means adding it
 //  to the current list of active sounds
@@ -323,23 +314,9 @@ static int      musicdies=-1;
 UINT8           music_started=0;
 boolean         songpaused=false;
 
-musictype_t I_GetMusicType(void)
-{
-	if (currsong)
-		return MU_MID;
-	else
-		return MU_NONE;
-}
-
-boolean I_MusicPlaying()
-{
-	return (boolean)currsong;
-}
-
-boolean I_MusicPaused()
-{
-	return songpaused;
-}
+/// ------------------------
+//  MUSIC SYSTEM
+/// ------------------------
 
 /* load_midi_mem:
  *  Loads a standard MIDI file from memory, returning a pointer to
@@ -427,69 +404,41 @@ void I_ShutdownMusic(void)
 	music_started=false;
 }
 
-boolean I_PlaySong(boolean looping)
-{
-	handle = 0;
-	if (midi_disabled)
-		return false;
+/// ------------------------
+//  MUSIC PROPERTIES
+/// ------------------------
 
-	islooping = looping;
-	musicdies = gametic + NEWTICRATE*30;
-	if (play_midi(currsong,looping)==0)
-		return true;
+musictype_t I_MusicType(void)
+{
+	if (currsong)
+		return MU_MID;
+	else
+		return MU_NONE;
+}
+
+boolean I_MusicPlaying()
+{
+	return (boolean)currsong;
+}
+
+boolean I_MusicPaused()
+{
+	return songpaused;
+}
+
+/// ------------------------
+//  MUSIC EFFECTS
+/// ------------------------
+
+boolean I_SetSongSpeed(float speed)
+{
+	(void)speed;
 	return false;
 }
 
-void I_PauseSong (INT32 handle)
-{
-	handle = 0;
-	if (midi_disabled)
-		return;
-	midi_pause();
-	songpaused = true;
-}
-
-void I_ResumeSong (INT32 handle)
-{
-	handle = 0;
-	if (midi_disabled)
-		return;
-	midi_resume();
-	songpaused = false;
-}
-
-void I_StopSong(void)
-{
-	handle = 0;
-	if (midi_disabled)
-		return;
-
-	islooping = 0;
-	musicdies = 0;
-	stop_midi();
-	songpaused = false;
-}
-
-// Is the song playing?
-#if 0
-int I_QrySongPlaying(int handle)
-{
-	if (midi_disabled)
-		return 0;
-
-	//return islooping || musicdies > gametic;
-	return (midi_pos==-1);
-}
-#endif
-
-void I_UnloadSong(void)
-{
-	handle = 0;
-	if (midi_disabled)
-		return;
-
-	//destroy_midi(currsong);
-}
+/// ------------------------
+//  MUSIC PLAYBACK
+/// ------------------------
 
 boolean I_LoadSong(char *data, size_t len)
 {
@@ -516,8 +465,81 @@ boolean I_LoadSong(char *data, size_t len)
 	return 1;
 }
 
-boolean I_SetSongSpeed(float speed)
+void I_UnloadSong(void)
 {
-	(void)speed;
+	handle = 0;
+	if (midi_disabled)
+		return;
+
+	//destroy_midi(currsong);
+}
+
+boolean I_PlaySong(boolean looping)
+{
+	handle = 0;
+	if (midi_disabled)
+		return false;
+
+	islooping = looping;
+	musicdies = gametic + NEWTICRATE*30;
+	if (play_midi(currsong,looping)==0)
+		return true;
 	return false;
 }
+
+void I_StopSong(void)
+{
+	handle = 0;
+	if (midi_disabled)
+		return;
+
+	islooping = 0;
+	musicdies = 0;
+	stop_midi();
+	songpaused = false;
+}
+
+void I_PauseSong (INT32 handle)
+{
+	handle = 0;
+	if (midi_disabled)
+		return;
+	midi_pause();
+	songpaused = true;
+}
+
+void I_ResumeSong (INT32 handle)
+{
+	handle = 0;
+	if (midi_disabled)
+		return;
+	midi_resume();
+	songpaused = false;
+}
+
+void I_SetMusicVolume(INT32 volume)
+{
+	if (midi_disabled)
+		return;
+
+	// Now set volume on output device.
+	set_volume (-1, Volset(volume));
+}
+
+boolean I_SetSongTrack(INT32 track)
+{
+	(void)track;
+	return false;
+}
+
+// Is the song playing?
+#if 0
+int I_QrySongPlaying(int handle)
+{
+	if (midi_disabled)
+		return 0;
+
+	//return islooping || musicdies > gametic;
+	return (midi_pos==-1);
+}
+#endif

--- a/src/djgppdos/i_sound.c
+++ b/src/djgppdos/i_sound.c
@@ -134,7 +134,7 @@ FUNCINLINE static ATTRINLINE int Volset(int vol)
 
 void I_SetSfxVolume(INT32 volume)
 {
-	if (nosound)
+	if (sound_disabled)
 		return;
 
 	set_volume (Volset(volume),-1);
@@ -142,7 +142,7 @@ void I_SetSfxVolume(INT32 volume)
 
 void I_SetMusicVolume(INT32 volume)
 {
-	if (nomidimusic)
+	if (midi_disabled)
 		return;
 
 	// Now set volume on output device.
@@ -169,7 +169,7 @@ INT32 I_StartSound ( sfxenum_t     id,
 {
 	int voice;
 
-	if (nosound)
+	if (sound_disabled)
 	return 0;
 
 	// UNUSED
@@ -190,7 +190,7 @@ void I_StopSound (INT32 handle)
 	//  an setting the channel to zero.
 	int voice=handle & (VIRTUAL_VOICES-1);
 
-	if (nosound)
+	if (sound_disabled)
 		return;
 
 	if (voice_check(voice)==S_sfx[handle>>VOICESSHIFT].data)
@@ -199,7 +199,7 @@ void I_StopSound (INT32 handle)
 
 INT32 I_SoundIsPlaying(INT32 handle)
 {
-	if (nosound)
+	if (sound_disabled)
 		return FALSE;
 
 	if (voice_check(handle & (VIRTUAL_VOICES-1))==S_sfx[handle>>VOICESSHIFT].data)
@@ -229,7 +229,7 @@ void I_UpdateSoundParams( INT32 handle,
 	int voice=handle & (VIRTUAL_VOICES-1);
 	int numsfx=handle>>VOICESSHIFT;
 
-	if (nosound)
+	if (sound_disabled)
 		return;
 
 	if (voice_check(voice)==S_sfx[numsfx].data)
@@ -270,17 +270,17 @@ void I_StartupSound(void)
 	char   err[255];
 #endif
 
-	if (nosound)
+	if (sound_disabled)
 		sfxcard=DIGI_NONE;
 	else
 		sfxcard=DIGI_AUTODETECT;
 
-	if (nomidimusic)
+	if (midi_disabled)
 		midicard=MIDI_NONE;
 	else
 		midicard=MIDI_AUTODETECT; //DetectMusicCard();
 
-	nodigimusic=true; //Alam: No OGG/MP3/IT/MOD support
+	digital_disabled=true; //Alam: No OGG/MP3/IT/MOD support
 
 	// Secure and configure sound device first.
 	CONS_Printf("I_StartupSound: ");
@@ -293,8 +293,8 @@ void I_StartupSound(void)
 	{
 		sprintf (err,"Sound init error : %s\n",allegro_error);
 		CONS_Error (err);
-		nosound=true;
-		nomidimusic=true;
+		sound_disabled=true;
+		midi_disabled=true;
 	}
 	else
 	{
@@ -409,7 +409,7 @@ static MIDI *load_midi_mem(char *mempointer,int *e)
 
 void I_InitMusic(void)
 {
-	if (nomidimusic)
+	if (midi_disabled)
 		return;
 
 	I_AddExitFunc(I_ShutdownMusic);
@@ -430,7 +430,7 @@ void I_ShutdownMusic(void)
 boolean I_PlaySong(boolean looping)
 {
 	handle = 0;
-	if (nomidimusic)
+	if (midi_disabled)
 		return false;
 
 	islooping = looping;
@@ -443,7 +443,7 @@ boolean I_PlaySong(boolean looping)
 void I_PauseSong (INT32 handle)
 {
 	handle = 0;
-	if (nomidimusic)
+	if (midi_disabled)
 		return;
 	midi_pause();
 	songpaused = true;
@@ -452,7 +452,7 @@ void I_PauseSong (INT32 handle)
 void I_ResumeSong (INT32 handle)
 {
 	handle = 0;
-	if (nomidimusic)
+	if (midi_disabled)
 		return;
 	midi_resume();
 	songpaused = false;
@@ -461,7 +461,7 @@ void I_ResumeSong (INT32 handle)
 void I_StopSong(void)
 {
 	handle = 0;
-	if (nomidimusic)
+	if (midi_disabled)
 		return;
 
 	islooping = 0;
@@ -474,7 +474,7 @@ void I_StopSong(void)
 #if 0
 int I_QrySongPlaying(int handle)
 {
-	if (nomidimusic)
+	if (midi_disabled)
 		return 0;
 
 	//return islooping || musicdies > gametic;
@@ -485,7 +485,7 @@ int I_QrySongPlaying(int handle)
 void I_UnloadSong(void)
 {
 	handle = 0;
-	if (nomidimusic)
+	if (midi_disabled)
 		return;
 
 	//destroy_midi(currsong);
@@ -494,7 +494,7 @@ void I_UnloadSong(void)
 boolean I_LoadSong(char *data, size_t len)
 {
 	int e = len; //Alam: For error
-	if (nomidimusic)
+	if (midi_disabled)
 		return 0;
 
 	if (memcmp(data,"MThd",4)==0) // support mid file in WAD !!!

--- a/src/djgppdos/i_sound.c
+++ b/src/djgppdos/i_sound.c
@@ -321,6 +321,7 @@ static MIDI* currsong;   //im assuming only 1 song will be played at once
 static int      islooping=0;
 static int      musicdies=-1;
 UINT8           music_started=0;
+boolean         songpaused=false;
 
 musictype_t I_GetMusicType(void)
 {
@@ -328,6 +329,16 @@ musictype_t I_GetMusicType(void)
 		return MU_MID;
 	else
 		return MU_NONE;
+}
+
+boolean I_MusicPlaying()
+{
+	return (boolean)currsong;
+}
+
+boolean I_MusicPaused()
+{
+	return songpaused;
 }
 
 /* load_midi_mem:
@@ -403,6 +414,7 @@ void I_InitMusic(void)
 
 	I_AddExitFunc(I_ShutdownMusic);
 	music_started = true;
+	songpaused = false;
 }
 
 void I_ShutdownMusic(void)
@@ -433,8 +445,8 @@ void I_PauseSong (INT32 handle)
 	handle = 0;
 	if (nomidimusic)
 		return;
-
 	midi_pause();
+	songpaused = true;
 }
 
 void I_ResumeSong (INT32 handle)
@@ -442,8 +454,8 @@ void I_ResumeSong (INT32 handle)
 	handle = 0;
 	if (nomidimusic)
 		return;
-
 	midi_resume();
+	songpaused = false;
 }
 
 void I_StopSong(void)
@@ -455,6 +467,7 @@ void I_StopSong(void)
 	islooping = 0;
 	musicdies = 0;
 	stop_midi();
+	songpaused = false;
 }
 
 // Is the song playing?

--- a/src/djgppdos/i_sound.c
+++ b/src/djgppdos/i_sound.c
@@ -140,7 +140,7 @@ void I_SetSfxVolume(INT32 volume)
 	set_volume (Volset(volume),-1);
 }
 
-void I_SetMIDIMusicVolume(INT32 volume)
+void I_SetMusicVolume(INT32 volume)
 {
 	if (nomidimusic)
 		return;
@@ -501,16 +501,6 @@ boolean I_LoadSong(char *data, size_t len)
 	}
 
 	return 1;
-}
-
-void I_SetDigMusicVolume(INT32 volume)
-{
-	volume = 0;
-	if (nodigimusic)
-		return;
-
-	// Now set volume on output device.
-//	CONS_Printf("Digital music not yet supported under DOS.\n");
 }
 
 boolean I_SetSongSpeed(float speed)

--- a/src/djgppdos/i_sound.c
+++ b/src/djgppdos/i_sound.c
@@ -408,7 +408,7 @@ void I_ShutdownMusic(void)
 //  MUSIC PROPERTIES
 /// ------------------------
 
-musictype_t I_MusicType(void)
+musictype_t I_SongType(void)
 {
 	if (currsong)
 		return MU_MID;
@@ -416,12 +416,12 @@ musictype_t I_MusicType(void)
 		return MU_NONE;
 }
 
-boolean I_MusicPlaying()
+boolean I_SongPlaying()
 {
 	return (boolean)currsong;
 }
 
-boolean I_MusicPaused()
+boolean I_SongPaused()
 {
 	return songpaused;
 }

--- a/src/djgppdos/i_sound.c
+++ b/src/djgppdos/i_sound.c
@@ -322,6 +322,13 @@ static int      islooping=0;
 static int      musicdies=-1;
 UINT8           music_started=0;
 
+musictype_t I_GetMusicType(void)
+{
+	if (currsong)
+		return MU_MID;
+	else
+		return MU_NONE;
+}
 
 /* load_midi_mem:
  *  Loads a standard MIDI file from memory, returning a pointer to
@@ -389,7 +396,7 @@ static MIDI *load_midi_mem(char *mempointer,int *e)
 	return midi;
 }
 
-void I_InitMIDIMusic(void)
+void I_InitMusic(void)
 {
 	if (nomidimusic)
 		return;
@@ -398,12 +405,12 @@ void I_InitMIDIMusic(void)
 	music_started = true;
 }
 
-void I_ShutdownMIDIMusic(void)
+void I_ShutdownMusic(void)
 {
 	if ( !music_started )
 		return;
 
-	I_StopSong(1);
+	I_StopSong();
 
 	music_started=false;
 }
@@ -439,7 +446,7 @@ void I_ResumeSong (INT32 handle)
 	midi_resume();
 }
 
-void I_StopSong(INT32 handle)
+void I_StopSong(void)
 {
 	handle = 0;
 	if (nomidimusic)
@@ -462,7 +469,7 @@ int I_QrySongPlaying(int handle)
 }
 #endif
 
-void I_UnRegisterSong(INT32 handle)
+void I_UnloadSong(void)
 {
 	handle = 0;
 	if (nomidimusic)
@@ -494,20 +501,6 @@ boolean I_LoadSong(char *data, size_t len)
 	}
 
 	return 1;
-}
-
-/// \todo Add OGG/MP3 support for dos
-boolean I_StartDigSong(const char *musicname, INT32 looping)
-{
-	musicname = NULL;
-	looping = 0;
-	//CONS_Printf("I_StartDigSong: Not yet supported under DOS.\n");
-	return false;
-}
-
-void I_StopDigSong(void)
-{
-//	CONS_Printf("I_StopDigSong: Not yet supported under DOS.\n");
 }
 
 void I_SetDigMusicVolume(INT32 volume)

--- a/src/djgppdos/i_sound.c
+++ b/src/djgppdos/i_sound.c
@@ -408,31 +408,7 @@ void I_ShutdownMIDIMusic(void)
 	music_started=false;
 }
 
-void I_InitDigMusic(void)
-{
-//	CONS_Printf("Digital music not yet supported under DOS.\n");
-}
-
-void I_ShutdownDigMusic(void)
-{
-//	CONS_Printf("Digital music not yet supported under DOS.\n");
-}
-
-void I_InitMusic(void)
-{
-	if (!nodigimusic)
-		I_InitDigMusic();
-	if (!nomidimusic)
-		I_InitMIDIMusic();
-}
-
-void I_ShutdownMusic(void)
-{
-	I_ShutdownMIDIMusic();
-	I_ShutdownDigMusic();
-}
-
-boolean I_PlaySong(INT32 handle, INT32 looping)
+boolean I_PlaySong(boolean looping)
 {
 	handle = 0;
 	if (nomidimusic)
@@ -495,7 +471,7 @@ void I_UnRegisterSong(INT32 handle)
 	//destroy_midi(currsong);
 }
 
-INT32 I_RegisterSong(void *data, size_t len)
+boolean I_LoadSong(char *data, size_t len)
 {
 	int e = len; //Alam: For error
 	if (nomidimusic)

--- a/src/doomstat.h
+++ b/src/doomstat.h
@@ -85,10 +85,7 @@ extern boolean fromlevelselect;
 // Internal parameters for sound rendering.
 // ========================================
 
-extern boolean nomidimusic; // defined in d_main.c
-extern boolean nosound;
-extern boolean nodigimusic;
-extern boolean music_disabled;
+extern boolean midi_disabled;
 extern boolean sound_disabled;
 extern boolean digital_disabled;
 

--- a/src/dummy/i_sound.c
+++ b/src/dummy/i_sound.c
@@ -57,11 +57,19 @@ void I_SetSfxVolume(UINT8 volume)
 	(void)volume;
 }
 
-//
-//  MUSIC I/O
-//
+/// ------------------------
+//  MUSIC SYSTEM
+/// ------------------------
 
-musictype_t I_GetMusicType(void)
+void I_InitMusic(void){}
+
+void I_ShutdownMusic(void){}
+
+/// ------------------------
+//  MUSIC PROPERTIES
+/// ------------------------
+
+musictype_t I_MusicType(void)
 {
 	return MU_NONE;
 }
@@ -76,34 +84,30 @@ boolean I_MusicPaused(void)
 	return false;
 }
 
-void I_InitMusic(void){}
+/// ------------------------
+//  MUSIC EFFECTS
+/// ------------------------
 
-void I_ShutdownMusic(void){}
-
-void I_SetMusicVolume(UINT8 volume)
+boolean I_SetSongSpeed(float speed)
 {
-	(void)volume;
+	(void)speed;
+	return false;
 }
 
-void I_PauseSong(void)
-{
-	(void)handle;
-}
-
-void I_ResumeSong(void)
-{
-	(void)handle;
-}
-
-//
-//  MIDI I/O
-//
+/// ------------------------
+//  MUSIC PLAYBACK
+/// ------------------------
 
 boolean I_LoadSong(char *data, size_t len)
 {
 	(void)data;
 	(void)len;
 	return -1;
+}
+
+void I_UnloadSong(void)
+{
+	(void)handle;
 }
 
 boolean I_PlaySong(boolean looping)
@@ -118,19 +122,19 @@ void I_StopSong(void)
 	(void)handle;
 }
 
-void I_UnloadSong(void)
+void I_PauseSong(void)
 {
 	(void)handle;
 }
 
-//
-//  DIGMUSIC I/O
-//
-
-boolean I_SetSongSpeed(float speed)
+void I_ResumeSong(void)
 {
-	(void)speed;
-	return false;
+	(void)handle;
+}
+
+void I_SetMusicVolume(UINT8 volume)
+{
+	(void)volume;
 }
 
 boolean I_SetSongTrack(int track)

--- a/src/dummy/i_sound.c
+++ b/src/dummy/i_sound.c
@@ -70,7 +70,7 @@ void I_InitMusic(void){}
 
 void I_ShutdownMusic(void){}
 
-void I_SetMIDIMusicVolume(UINT8 volume)
+void I_SetMusicVolume(UINT8 volume)
 {
 	(void)volume;
 }
@@ -116,11 +116,6 @@ void I_UnloadSong(void)
 //
 //  DIGMUSIC I/O
 //
-
-void I_SetDigMusicVolume(UINT8 volume)
-{
-	(void)volume;
-}
 
 boolean I_SetSongSpeed(float speed)
 {

--- a/src/dummy/i_sound.c
+++ b/src/dummy/i_sound.c
@@ -66,6 +66,16 @@ musictype_t I_GetMusicType(void)
 	return MU_NONE;
 }
 
+boolean I_MusicPlaying(void)
+{
+	return false;
+}
+
+boolean I_MusicPaused(void)
+{
+	return false;
+}
+
 void I_InitMusic(void){}
 
 void I_ShutdownMusic(void){}

--- a/src/dummy/i_sound.c
+++ b/src/dummy/i_sound.c
@@ -69,17 +69,17 @@ void I_ShutdownMusic(void){}
 //  MUSIC PROPERTIES
 /// ------------------------
 
-musictype_t I_MusicType(void)
+musictype_t I_SongType(void)
 {
 	return MU_NONE;
 }
 
-boolean I_MusicPlaying(void)
+boolean I_SongPlaying(void)
 {
 	return false;
 }
 
-boolean I_MusicPaused(void)
+boolean I_SongPaused(void)
 {
 	return false;
 }

--- a/src/dummy/i_sound.c
+++ b/src/dummy/i_sound.c
@@ -70,7 +70,7 @@ void I_PauseSong(INT32 handle)
 	(void)handle;
 }
 
-void I_ResumeSong(INT32 handle)
+void I_ResumeSong(void)
 {
 	(void)handle;
 }
@@ -79,23 +79,14 @@ void I_ResumeSong(INT32 handle)
 //  MIDI I/O
 //
 
-void I_InitMIDIMusic(void){}
-
-void I_ShutdownMIDIMusic(void){}
-
-void I_SetMIDIMusicVolume(UINT8 volume)
-{
-	(void)volume;
-}
-
-INT32 I_RegisterSong(void *data, size_t len)
+boolean I_LoadSong(char *data, size_t len)
 {
 	(void)data;
 	(void)len;
 	return -1;
 }
 
-boolean I_PlaySong(INT32 handle, boolean looping)
+boolean I_PlaySong(boolean looping)
 {
 	(void)handle;
 	(void)looping;

--- a/src/dummy/i_sound.c
+++ b/src/dummy/i_sound.c
@@ -61,11 +61,21 @@ void I_SetSfxVolume(UINT8 volume)
 //  MUSIC I/O
 //
 
+musictype_t I_GetMusicType(void)
+{
+	return MU_NONE;
+}
+
 void I_InitMusic(void){}
 
 void I_ShutdownMusic(void){}
 
-void I_PauseSong(INT32 handle)
+void I_SetMIDIMusicVolume(UINT8 volume)
+{
+	(void)volume;
+}
+
+void I_PauseSong(void)
 {
 	(void)handle;
 }
@@ -93,12 +103,12 @@ boolean I_PlaySong(boolean looping)
 	return false;
 }
 
-void I_StopSong(INT32 handle)
+void I_StopSong(void)
 {
 	(void)handle;
 }
 
-void I_UnRegisterSong(INT32 handle)
+void I_UnloadSong(void)
 {
 	(void)handle;
 }
@@ -106,19 +116,6 @@ void I_UnRegisterSong(INT32 handle)
 //
 //  DIGMUSIC I/O
 //
-
-void I_InitDigMusic(void){}
-
-void I_ShutdownDigMusic(void){}
-
-boolean I_StartDigSong(const char *musicname, boolean looping)
-{
-	(void)musicname;
-	(void)looping;
-	return false;
-}
-
-void I_StopDigSong(void){}
 
 void I_SetDigMusicVolume(UINT8 volume)
 {

--- a/src/hardware/hw3sound.c
+++ b/src/hardware/hw3sound.c
@@ -361,7 +361,7 @@ INT32 HW3S_I_StartSound(const void *origin_p, source3D_data_t *source_parm, chan
 
 	if (splitscreen) listenmobj2 = players[secondarydisplayplayer].mo;
 
-	if (nosound)
+	if (sound_disabled)
 		return -1;
 
 	sfx = &S_sfx[sfx_id];

--- a/src/i_sound.h
+++ b/src/i_sound.h
@@ -18,6 +18,21 @@
 #include "sounds.h"
 #include "command.h"
 
+// copied from SDL mixer, plus GME
+typedef enum {
+	MU_NONE,
+	MU_CMD,
+	MU_WAV,
+	MU_MOD,
+	MU_MID,
+	MU_OGG,
+	MU_MP3,
+	MU_MP3_MAD_UNUSED, // use MU_MP3 instead
+	MU_FLAC,
+	MU_MODPLUG_UNUSED, // use MU_MOD instead
+	MU_GME
+} musictype_t;
+
 /**	\brief Sound subsystem runing and waiting
 */
 extern UINT8 sound_started;
@@ -108,6 +123,9 @@ void I_SetSfxVolume(UINT8 volume);
 //
 //  MUSIC I/O
 //
+
+musictype_t I_GetMusicType(void);
+
 /** \brief Init the music systems
 */
 void I_InitMusic(void);

--- a/src/i_sound.h
+++ b/src/i_sound.h
@@ -136,9 +136,9 @@ void I_ShutdownMusic(void);
 //  MUSIC PROPERTIES
 /// ------------------------
 
-musictype_t I_MusicType(void);
-boolean I_MusicPlaying(void);
-boolean I_MusicPaused(void);
+musictype_t I_SongType(void);
+boolean I_SongPlaying(void);
+boolean I_SongPaused(void);
 
 /// ------------------------
 //  MUSIC EFFECTS

--- a/src/i_sound.h
+++ b/src/i_sound.h
@@ -125,6 +125,8 @@ void I_SetSfxVolume(UINT8 volume);
 //
 
 musictype_t I_GetMusicType(void);
+boolean I_MusicPlaying(void);
+boolean I_MusicPaused(void);
 
 /** \brief Init the music systems
 */

--- a/src/i_sound.h
+++ b/src/i_sound.h
@@ -66,9 +66,9 @@ void I_StartupSound(void);
 */
 void I_ShutdownSound(void);
 
-//
-//  SFX I/O
-//
+/// ------------------------
+///  SFX I/O
+/// ------------------------
 
 /**	\brief	Starts a sound in a particular sound channel.
 	\param	id	sfxid
@@ -120,13 +120,9 @@ void I_UpdateSoundParams(INT32 handle, UINT8 vol, UINT8 sep, UINT8 pitch);
 */
 void I_SetSfxVolume(UINT8 volume);
 
-//
-//  MUSIC I/O
-//
-
-musictype_t I_GetMusicType(void);
-boolean I_MusicPlaying(void);
-boolean I_MusicPaused(void);
+/// ------------------------
+//  MUSIC SYSTEM
+/// ------------------------
 
 /** \brief Init the music systems
 */
@@ -136,33 +132,23 @@ void I_InitMusic(void);
 */
 void I_ShutdownMusic(void);
 
-/**	\brief	PAUSE game handling.
+/// ------------------------
+//  MUSIC PROPERTIES
+/// ------------------------
 
-	\param	handle	song handle
+musictype_t I_MusicType(void);
+boolean I_MusicPlaying(void);
+boolean I_MusicPaused(void);
 
-	\return	void
-*/
-void I_PauseSong(void);
+/// ------------------------
+//  MUSIC EFFECTS
+/// ------------------------
 
-/**	\brief	RESUME game handling
+boolean I_SetSongSpeed(float speed);
 
-	\param	handle	song handle
-
-	\return	void
-*/
-void I_ResumeSong(void);
-
-//
-//  MIDI I/O
-//
-
-/**	\brief	The I_SetMIDIMusicVolume function
-
-	\param	volume	volume to set at
-
-	\return	void
-*/
-void I_SetMIDIMusicVolume(UINT8 volume);
+/// ------------------------
+//  MUSIC PLAYBACK
+/// ------------------------
 
 /**	\brief	Registers a song handle to song data.
 
@@ -174,6 +160,15 @@ void I_SetMIDIMusicVolume(UINT8 volume);
 	\todo Remove this
 */
 boolean I_LoadSong(char *data, size_t len);
+
+/**	\brief	See ::I_LoadSong, then think backwards
+
+	\param	handle	song handle
+
+	\sa I_LoadSong
+	\todo remove midi handle
+*/
+void I_UnloadSong(void);
 
 /**	\brief	Called by anything that wishes to start music
 
@@ -195,35 +190,35 @@ boolean I_PlaySong(boolean looping);
 */
 void I_StopSong(void);
 
-/**	\brief	See ::I_LoadSong, then think backwards
+/**	\brief	PAUSE game handling.
 
 	\param	handle	song handle
 
-	\sa I_LoadSong
-	\todo remove midi handle
+	\return	void
 */
-void I_UnloadSong(void);
+void I_PauseSong(void);
 
-//
-//  DIGMUSIC I/O
-//
+/**	\brief	RESUME game handling
 
-boolean I_SetSongSpeed(float speed);
+	\param	handle	song handle
 
-boolean I_SetSongTrack(INT32 track);
+	\return	void
+*/
+void I_ResumeSong(void);
 
-/**	\brief The I_SetDigMusicVolume function
+/**	\brief	The I_SetMusicVolume function
 
 	\param	volume	volume to set at
 
 	\return	void
 */
-void I_SetDigMusicVolume(UINT8 volume);
+void I_SetMusicVolume(UINT8 volume);
 
-//
-// CD MUSIC I/O
-//
+boolean I_SetSongTrack(INT32 track);
 
+/// ------------------------
+//  CD MUSIC I/O
+/// ------------------------
 
 /**	\brief  cd music interface
 */

--- a/src/i_sound.h
+++ b/src/i_sound.h
@@ -140,7 +140,7 @@ void I_ShutdownMusic(void);
 
 	\return	void
 */
-void I_PauseSong(INT32 handle);
+void I_PauseSong(void);
 
 /**	\brief	RESUME game handling
 
@@ -148,19 +148,11 @@ void I_PauseSong(INT32 handle);
 
 	\return	void
 */
-void I_ResumeSong(INT32 handle);
+void I_ResumeSong(void);
 
 //
 //  MIDI I/O
 //
-
-/**	\brief Startup the MIDI music system
-*/
-void I_InitMIDIMusic(void);
-
-/**	\brief Shutdown the MIDI music system
-*/
-void I_ShutdownMIDIMusic(void);
 
 /**	\brief	The I_SetMIDIMusicVolume function
 
@@ -179,7 +171,7 @@ void I_SetMIDIMusicVolume(UINT8 volume);
 
 	\todo Remove this
 */
-INT32 I_RegisterSong(void *data, size_t len);
+boolean I_LoadSong(char *data, size_t len);
 
 /**	\brief	Called by anything that wishes to start music
 
@@ -190,7 +182,7 @@ INT32 I_RegisterSong(void *data, size_t len);
 
 	\todo pass music name, not handle
 */
-boolean I_PlaySong(INT32 handle, boolean looping);
+boolean I_PlaySong(boolean looping);
 
 /**	\brief	Stops a song over 3 seconds
 
@@ -199,45 +191,24 @@ boolean I_PlaySong(INT32 handle, boolean looping);
 
 	/todo drop handle
 */
-void I_StopSong(INT32 handle);
+void I_StopSong(void);
 
-/**	\brief	See ::I_RegisterSong, then think backwards
+/**	\brief	See ::I_LoadSong, then think backwards
 
 	\param	handle	song handle
 
-	\sa I_RegisterSong
+	\sa I_LoadSong
 	\todo remove midi handle
 */
-void I_UnRegisterSong(INT32 handle);
+void I_UnloadSong(void);
 
 //
 //  DIGMUSIC I/O
 //
 
-/**	\brief Startup the music system
-*/
-void I_InitDigMusic(void);
-
-/**	\brief Shutdown the music system
-*/
-void I_ShutdownDigMusic(void);
-
 boolean I_SetSongSpeed(float speed);
 
 boolean I_SetSongTrack(INT32 track);
-
-/**	\brief The I_StartDigSong function
-
-	\param	musicname	music lump name
-	\param	looping	if true, loop the song
-
-	\return	if true, song playing
-*/
-boolean I_StartDigSong(const char *musicname, boolean looping);
-
-/**	\brief stop non-MIDI song
-*/
-void I_StopDigSong(void);
 
 /**	\brief The I_SetDigMusicVolume function
 

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -6950,11 +6950,11 @@ static void M_ChangeControl(INT32 choice)
 // Toggles sound systems in-game.
 static void M_ToggleSFX(void)
 {
-	if (nosound)
+	if (sound_disabled)
 	{
-		nosound = false;
+		sound_disabled = false;
 		I_StartupSound();
-		if (nosound) return;
+		if (sound_disabled) return;
 		S_InitSfxChannels(cv_soundvolume.value);
 		M_StartMessage(M_GetText("SFX Enabled\n"), NULL, MM_NOTHING);
 	}
@@ -6976,56 +6976,44 @@ static void M_ToggleSFX(void)
 
 static void M_ToggleDigital(void)
 {
-	if (nodigimusic)
+	if (digital_disabled)
 	{
-		nodigimusic = false;
-		I_InitDigMusic();
-		if (nodigimusic) return;
-		S_InitSfxChannels(cv_soundvolume.value);
+		digital_disabled = false;
+		I_InitMusic();
+		if (digital_disabled) return;
 		S_StopMusic();
-		S_ChangeMusicInternal("lclear", false);
+		if (Playing())
+			P_RestoreMusic(&players[consoleplayer]);
+		else
+			S_ChangeMusicInternal("lclear", false);
 		M_StartMessage(M_GetText("Digital Music Enabled\n"), NULL, MM_NOTHING);
 	}
 	else
 	{
-		if (digital_disabled)
-		{
-			digital_disabled = false;
-			M_StartMessage(M_GetText("Digital Music Enabled\n"), NULL, MM_NOTHING);
-		}
-		else
-		{
-			digital_disabled = true;
-			S_StopMusic();
-			M_StartMessage(M_GetText("Digital Music Disabled\n"), NULL, MM_NOTHING);
-		}
+		digital_disabled = true;
+		S_StopMusic();
+		M_StartMessage(M_GetText("Digital Music Disabled\n"), NULL, MM_NOTHING);
 	}
 }
 
 static void M_ToggleMIDI(void)
 {
-	if (nomidimusic)
+	if (midi_disabled)
 	{
-		nomidimusic = false;
-		I_InitMIDIMusic();
-		if (nomidimusic) return;
-		S_InitSfxChannels(cv_soundvolume.value);
-		S_ChangeMusicInternal("lclear", false);
+		midi_disabled = false;
+		I_InitMusic();
+		if (midi_disabled) return;
+		if (Playing())
+			P_RestoreMusic(&players[consoleplayer]);
+		else
+			S_ChangeMusicInternal("lclear", false);
 		M_StartMessage(M_GetText("MIDI Music Enabled\n"), NULL, MM_NOTHING);
 	}
 	else
 	{
-		if (music_disabled)
-		{
-			music_disabled = false;
-			M_StartMessage(M_GetText("MIDI Music Enabled\n"), NULL, MM_NOTHING);
-		}
-		else
-		{
-			music_disabled = true;
-			S_StopMusic();
-			M_StartMessage(M_GetText("MIDI Music Disabled\n"), NULL, MM_NOTHING);
-		}
+		midi_disabled = true;
+		S_StopMusic();
+		M_StartMessage(M_GetText("MIDI Music Disabled\n"), NULL, MM_NOTHING);
 	}
 }
 

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -6991,7 +6991,8 @@ static void M_ToggleDigital(void)
 	else
 	{
 		digital_disabled = true;
-		S_StopMusic();
+		if (S_MusicType() != MU_MID)
+			S_StopMusic();
 		M_StartMessage(M_GetText("Digital Music Disabled\n"), NULL, MM_NOTHING);
 	}
 }
@@ -7012,7 +7013,8 @@ static void M_ToggleMIDI(void)
 	else
 	{
 		midi_disabled = true;
-		S_StopMusic();
+		if (S_MusicType() == MU_MID)
+			S_StopMusic();
 		M_StartMessage(M_GetText("MIDI Music Disabled\n"), NULL, MM_NOTHING);
 	}
 }

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -6992,7 +6992,24 @@ static void M_ToggleDigital(void)
 	{
 		digital_disabled = true;
 		if (S_MusicType() != MU_MID)
-			S_StopMusic();
+		{
+			if (midi_disabled)
+				S_StopMusic();
+			else
+			{
+				char mmusic[7];
+				UINT16 mflags;
+				boolean looping;
+
+				if (S_MusicInfo(mmusic, &mflags, &looping) && S_MIDIExists(mmusic))
+				{
+					S_StopMusic();
+					S_ChangeMusic(mmusic, mflags, looping);
+				}
+				else
+					S_StopMusic();
+			}
+		}
 		M_StartMessage(M_GetText("Digital Music Disabled\n"), NULL, MM_NOTHING);
 	}
 }
@@ -7014,7 +7031,24 @@ static void M_ToggleMIDI(void)
 	{
 		midi_disabled = true;
 		if (S_MusicType() == MU_MID)
-			S_StopMusic();
+		{
+			if (digital_disabled)
+				S_StopMusic();
+			else
+			{
+				char mmusic[7];
+				UINT16 mflags;
+				boolean looping;
+
+				if (S_MusicInfo(mmusic, &mflags, &looping) && S_DigExists(mmusic))
+				{
+					S_StopMusic();
+					S_ChangeMusic(mmusic, mflags, looping);
+				}
+				else
+					S_StopMusic();
+			}
+		}
 		M_StartMessage(M_GetText("MIDI Music Disabled\n"), NULL, MM_NOTHING);
 	}
 }

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -6954,23 +6954,15 @@ static void M_ToggleSFX(void)
 	{
 		sound_disabled = false;
 		I_StartupSound();
-		if (sound_disabled) return;
 		S_InitSfxChannels(cv_soundvolume.value);
+		S_StartSound(NULL, sfx_strpst);
 		M_StartMessage(M_GetText("SFX Enabled\n"), NULL, MM_NOTHING);
 	}
 	else
 	{
-		if (sound_disabled)
-		{
-			sound_disabled = false;
-			M_StartMessage(M_GetText("SFX Enabled\n"), NULL, MM_NOTHING);
-		}
-		else
-		{
-			sound_disabled = true;
-			S_StopSounds();
-			M_StartMessage(M_GetText("SFX Disabled\n"), NULL, MM_NOTHING);
-		}
+		sound_disabled = true;
+		S_StopSounds();
+		M_StartMessage(M_GetText("SFX Disabled\n"), NULL, MM_NOTHING);
 	}
 }
 
@@ -6980,7 +6972,6 @@ static void M_ToggleDigital(void)
 	{
 		digital_disabled = false;
 		I_InitMusic();
-		if (digital_disabled) return;
 		S_StopMusic();
 		if (Playing())
 			P_RestoreMusic(&players[consoleplayer]);
@@ -7020,7 +7011,6 @@ static void M_ToggleMIDI(void)
 	{
 		midi_disabled = false;
 		I_InitMusic();
-		if (midi_disabled) return;
 		if (Playing())
 			P_RestoreMusic(&players[consoleplayer]);
 		else

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -6955,7 +6955,7 @@ static void M_ToggleSFX(void)
 		nosound = false;
 		I_StartupSound();
 		if (nosound) return;
-		S_Init(cv_soundvolume.value, cv_digmusicvolume.value, cv_midimusicvolume.value);
+		S_InitSfxChannels(cv_soundvolume.value);
 		M_StartMessage(M_GetText("SFX Enabled\n"), NULL, MM_NOTHING);
 	}
 	else
@@ -6981,7 +6981,7 @@ static void M_ToggleDigital(void)
 		nodigimusic = false;
 		I_InitDigMusic();
 		if (nodigimusic) return;
-		S_Init(cv_soundvolume.value, cv_digmusicvolume.value, cv_midimusicvolume.value);
+		S_InitSfxChannels(cv_soundvolume.value);
 		S_StopMusic();
 		S_ChangeMusicInternal("lclear", false);
 		M_StartMessage(M_GetText("Digital Music Enabled\n"), NULL, MM_NOTHING);
@@ -7009,7 +7009,7 @@ static void M_ToggleMIDI(void)
 		nomidimusic = false;
 		I_InitMIDIMusic();
 		if (nomidimusic) return;
-		S_Init(cv_soundvolume.value, cv_digmusicvolume.value, cv_midimusicvolume.value);
+		S_InitSfxChannels(cv_soundvolume.value);
 		S_ChangeMusicInternal("lclear", false);
 		M_StartMessage(M_GetText("MIDI Music Enabled\n"), NULL, MM_NOTHING);
 	}

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -6953,7 +6953,6 @@ static void M_ToggleSFX(void)
 	if (sound_disabled)
 	{
 		sound_disabled = false;
-		I_StartupSound();
 		S_InitSfxChannels(cv_soundvolume.value);
 		S_StartSound(NULL, sfx_strpst);
 		M_StartMessage(M_GetText("SFX Enabled\n"), NULL, MM_NOTHING);

--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -8228,7 +8228,7 @@ void P_PrecipitationEffects(void)
 	if (!playeringame[displayplayer] || !players[displayplayer].mo)
 		return;
 
-	if (nosound || sound_disabled)
+	if (sound_disabled)
 		return; // Sound off? D'aw, no fun.
 
 	if (players[displayplayer].mo->subsector->sector->ceilingpic == skyflatnum)

--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -1378,7 +1378,7 @@ void S_ChangeMusic(const char *mmusic, UINT16 mflags, boolean looping)
 		return;
 	}
 
-	if (strncmp(music_name, mmusic, 6))
+	if (strnicmp(music_name, newmusic, 6))
 	{
 		S_StopMusic(); // shutdown old music
 

--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -1391,14 +1391,17 @@ void S_ChangeMusic(const char *mmusic, UINT16 mflags, boolean looping)
 		S_StopMusic(); // shutdown old music
 
 		if (!S_LoadMusic(mmusic))
+		{
+			CONS_Alert(CONS_ERROR, "Music %.6s could not be loaded!\n", mmusic);
 			return;
+		}
 
 		music_flags = mflags;
 		music_looping = looping;
 
 		if (!S_PlayMusic(looping))
 		{
-			CONS_Alert(CONS_ERROR, "Music cannot be played!\n");
+			CONS_Alert(CONS_ERROR, "Music %.6s could not be played!\n", mmusic);
 			return;
 		}
 	}

--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -1245,6 +1245,11 @@ boolean S_MusicPaused(void)
 	return I_MusicPaused();
 }
 
+musictype_t S_MusicType(void)
+{
+	return I_GetMusicType();
+}
+
 const char *S_MusicName(void)
 {
 	return music_name;
@@ -1279,20 +1284,24 @@ static boolean S_LoadMusic(const char *mname)
 	if (S_MusicDisabled())
 		return false;
 
-	if (S_DigMusicDisabled())
-	{
-		if (!S_MIDIExists(mname))
-			return false;
+	if (!S_DigMusicDisabled() && S_DigExists(mname))
+		mlumpnum = W_GetNumForName(va("o_%s", mname));
+	else if (!S_MIDIMusicDisabled() && S_MIDIExists(mname))
 		mlumpnum = W_GetNumForName(va("d_%s", mname));
+	else if (S_DigMusicDisabled() && S_DigExists(mname))
+	{
+		CONS_Alert(CONS_NOTICE, "Digital music is disabled!\n");
+		return false;
+	}
+	else if (S_MIDIMusicDisabled() && S_MIDIExists(mname))
+	{
+		CONS_Alert(CONS_NOTICE, "MIDI music is disabled!\n");
+		return false;
 	}
 	else
 	{
-		if (S_DigExists(mname))
-			mlumpnum = W_GetNumForName(va("o_%s", mname));
-		else if (S_MIDIExists(mname))
-			mlumpnum = W_GetNumForName(va("d_%s", mname));
-		else
-			return false;
+		CONS_Alert(CONS_ERROR, M_GetText("Music lump %.6s not found!\n"), mname);
+		return false;
 	}
 
 	// load & register it
@@ -1328,8 +1337,8 @@ static void S_UnloadMusic(void)
 
 static boolean S_PlayMusic(boolean looping)
 {
-	if (S_DigMusicDisabled())
-		return false; // try midi
+	if (S_MusicDisabled())
+		return false;
 
 	if (!I_PlaySong(looping))
 	{
@@ -1362,10 +1371,7 @@ void S_ChangeMusic(const char *mmusic, UINT16 mflags, boolean looping)
 		S_StopMusic(); // shutdown old music
 
 		if (!S_LoadMusic(mmusic))
-		{
-			CONS_Alert(CONS_ERROR, M_GetText("Music lump %.6s not found!\n"), mmusic);
 			return;
-		}
 
 		if (!S_PlayMusic(looping))
 		{

--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -1215,6 +1215,8 @@ const char *compat_special_music_slots[16] =
 #endif
 
 static char      music_name[7]; // up to 6-character name
+static UINT16    music_flags;
+static boolean   music_looping;
 
 /// ------------------------
 /// Music Status
@@ -1250,9 +1252,17 @@ musictype_t S_MusicType(void)
 	return I_GetMusicType();
 }
 
-const char *S_MusicName(void)
+boolean S_MusicInfo(char *mname, UINT16 *mflags, boolean *looping)
 {
-	return music_name;
+	if (!I_MusicPlaying())
+		return false;
+
+	strncpy(mname, music_name, 7);
+	mname[6] = 0;
+	*mflags = music_flags;
+	*looping = music_looping;
+
+	return (boolean)mname[0];
 }
 
 boolean S_MusicExists(const char *mname, boolean checkMIDI, boolean checkDigi)
@@ -1333,6 +1343,8 @@ static void S_UnloadMusic(void)
 {
 	I_UnloadSong();
 	music_name[0] = 0;
+	music_flags = 0;
+	music_looping = false;
 }
 
 static boolean S_PlayMusic(boolean looping)
@@ -1372,6 +1384,9 @@ void S_ChangeMusic(const char *mmusic, UINT16 mflags, boolean looping)
 
 		if (!S_LoadMusic(mmusic))
 			return;
+
+		music_flags = mflags;
+		music_looping = looping;
 
 		if (!S_PlayMusic(looping))
 		{

--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -1465,11 +1465,13 @@ void S_SetMusicVolume(INT32 digvolume, INT32 seqvolume)
 	switch(I_SongType())
 	{
 		case MU_MID:
-		case MU_MOD:
-		case MU_GME:
+		//case MU_MOD:
+		//case MU_GME:
 			I_SetMusicVolume(seqvolume&31);
+			break;
 		default:
 			I_SetMusicVolume(digvolume&31);
+			break;
 	}
 }
 

--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -1239,22 +1239,22 @@ boolean S_MusicDisabled(void)
 
 boolean S_MusicPlaying(void)
 {
-	return I_MusicPlaying();
+	return I_SongPlaying();
 }
 
 boolean S_MusicPaused(void)
 {
-	return I_MusicPaused();
+	return I_SongPaused();
 }
 
 musictype_t S_MusicType(void)
 {
-	return I_MusicType();
+	return I_SongType();
 }
 
 boolean S_MusicInfo(char *mname, UINT16 *mflags, boolean *looping)
 {
-	if (!I_MusicPlaying())
+	if (!I_SongPlaying())
 		return false;
 
 	strncpy(mname, music_name, 7);
@@ -1399,10 +1399,10 @@ void S_ChangeMusic(const char *mmusic, UINT16 mflags, boolean looping)
 
 void S_StopMusic(void)
 {
-	if (!I_MusicPlaying())
+	if (!I_SongPlaying())
 		return;
 
-	if (I_MusicPaused())
+	if (I_SongPaused())
 		I_ResumeSong();
 
 	S_SpeedMusic(1.0f);
@@ -1421,7 +1421,7 @@ void S_StopMusic(void)
 //
 void S_PauseAudio(void)
 {
-	if (I_MusicPlaying() && !I_MusicPaused())
+	if (I_SongPlaying() && !I_SongPaused())
 		I_PauseSong();
 
 	// pause cd music
@@ -1434,7 +1434,7 @@ void S_PauseAudio(void)
 
 void S_ResumeAudio(void)
 {
-	if (I_MusicPlaying() && I_MusicPaused())
+	if (I_SongPlaying() && I_SongPaused())
 		I_ResumeSong();
 
 	// resume cd music
@@ -1462,7 +1462,7 @@ void S_SetMusicVolume(INT32 digvolume, INT32 seqvolume)
 	digvolume = seqvolume = 31;
 #endif
 
-	switch(I_MusicType())
+	switch(I_SongType())
 	{
 		case MU_MID:
 		case MU_MOD:

--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -1378,7 +1378,7 @@ void S_ChangeMusic(const char *mmusic, UINT16 mflags, boolean looping)
 		return;
 	}
 
-	if (strnicmp(music_name, newmusic, 6))
+	if (strnicmp(music_name, mmusic, 6))
 	{
 		S_StopMusic(); // shutdown old music
 

--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -1227,7 +1227,7 @@ static boolean S_MIDIMusic(const char *mname, boolean looping)
 	return true;
 }
 
-static boolean S_DigMusic(const char *mname, boolean looping)
+static boolean S_PlayMusic(boolean looping)
 {
 	if (nodigimusic || digital_disabled)
 		return false; // try midi
@@ -1235,11 +1235,6 @@ static boolean S_DigMusic(const char *mname, boolean looping)
 	if (!I_StartDigSong(mname, looping))
 		return false;
 
-	strncpy(music_name, mname, 7);
-	music_name[6] = 0;
-	music_lumpnum = LUMPERROR;
-	music_data = NULL;
-	music_handle = 0;
 	return true;
 }
 
@@ -1262,9 +1257,16 @@ void S_ChangeMusic(const char *mmusic, UINT16 mflags, boolean looping)
 	if (strncmp(music_name, mmusic, 6))
 	{
 		S_StopMusic(); // shutdown old music
-		if (!S_DigMusic(mmusic, looping) && !S_MIDIMusic(mmusic, looping))
+
+		if (!S_LoadMusic(mmusic))
 		{
 			CONS_Alert(CONS_ERROR, M_GetText("Music lump %.6s not found!\n"), mmusic);
+			return;
+		}
+
+		if (!S_PlayMusic(looping))
+		{
+			CONS_Alert(CONS_ERROR, "Music cannot be played!\n");
 			return;
 		}
 	}

--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -1249,7 +1249,7 @@ boolean S_MusicPaused(void)
 
 musictype_t S_MusicType(void)
 {
-	return I_GetMusicType();
+	return I_MusicType();
 }
 
 boolean S_MusicInfo(char *mname, UINT16 *mflags, boolean *looping)
@@ -1274,7 +1274,7 @@ boolean S_MusicExists(const char *mname, boolean checkMIDI, boolean checkDigi)
 }
 
 /// ------------------------
-/// Music Properties
+/// Music Effects
 /// ------------------------
 
 boolean S_SpeedMusic(float speed)
@@ -1283,7 +1283,7 @@ boolean S_SpeedMusic(float speed)
 }
 
 /// ------------------------
-/// Music Routines
+/// Music Playback
 /// ------------------------
 
 static boolean S_LoadMusic(const char *mname)
@@ -1462,7 +1462,7 @@ void S_SetMusicVolume(INT32 digvolume, INT32 seqvolume)
 	digvolume = seqvolume = 31;
 #endif
 
-	switch(I_GetMusicType())
+	switch(I_MusicType())
 	{
 		case MU_MID:
 		case MU_MOD:

--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -1215,6 +1215,7 @@ const char *compat_special_music_slots[16] =
 #endif
 
 static char      music_name[7]; // up to 6-character name
+static void      *music_data;
 static UINT16    music_flags;
 static boolean   music_looping;
 
@@ -1333,6 +1334,7 @@ static boolean S_LoadMusic(const char *mname)
 	{
 		strncpy(music_name, mname, 7);
 		music_name[6] = 0;
+		music_data = mdata;
 		return true;
 	}
 	else
@@ -1343,6 +1345,10 @@ static void S_UnloadMusic(void)
 {
 	I_UnloadSong();
 	music_name[0] = 0;
+#ifndef HAVE_SDL //SDL uses RWOPS
+	Z_ChangeTag(music_data, PU_CACHE);
+#endif
+	music_data = NULL;
 	music_flags = 0;
 	music_looping = false;
 }

--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -1344,11 +1344,13 @@ static boolean S_LoadMusic(const char *mname)
 static void S_UnloadMusic(void)
 {
 	I_UnloadSong();
-	music_name[0] = 0;
+
 #ifndef HAVE_SDL //SDL uses RWOPS
 	Z_ChangeTag(music_data, PU_CACHE);
 #endif
 	music_data = NULL;
+
+	music_name[0] = 0;
 	music_flags = 0;
 	music_looping = false;
 }
@@ -1413,13 +1415,7 @@ void S_StopMusic(void)
 
 	S_SpeedMusic(1.0f);
 	I_StopSong();
-	I_UnloadSong();
-
-#ifndef HAVE_SDL //SDL uses RWOPS
-	Z_ChangeTag(music_data, PU_CACHE);
-#endif
-
-	music_name[0] = 0;
+	S_UnloadMusic(); // for now, stopping also means you unload the song
 }
 
 //

--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -226,7 +226,7 @@ void S_RegisterSoundStuff(void)
 {
 	if (dedicated)
 	{
-		nosound = true;
+		sound_disabled = true;
 		return;
 	}
 
@@ -400,7 +400,7 @@ void S_StartSoundAtVolume(const void *origin_p, sfxenum_t sfx_id, INT32 volume)
 	mobj_t *listenmobj = players[displayplayer].mo;
 	mobj_t *listenmobj2 = NULL;
 
-	if (sound_disabled || !sound_started || nosound)
+	if (sound_disabled || !sound_started)
 		return;
 
 	// Don't want a sound? Okay then...
@@ -716,7 +716,7 @@ void S_UpdateSounds(void)
 		return;
 	}
 
-	if (dedicated || nosound)
+	if (dedicated || sound_disabled)
 		return;
 
 	if (players[displayplayer].awayviewtics)
@@ -1175,7 +1175,7 @@ void S_InitSfxChannels(INT32 sfxVolume)
 	}
 
 	// precache sounds if requested by cmdline, or precachesound var true
-	if (!nosound && (M_CheckParm("-precachesound") || precachesound.value))
+	if (!sound_disabled && (M_CheckParm("-precachesound") || precachesound.value))
 	{
 		// Initialize external data (all sounds) at start, keep static.
 		CONS_Printf(M_GetText("Loading sounds... "));
@@ -1220,24 +1220,19 @@ static char      music_name[7]; // up to 6-character name
 /// Music Status
 /// ------------------------
 
-boolean S_DigMusicDisabled()
+boolean S_DigMusicDisabled(void)
 {
-	return (nodigimusic || digital_disabled);
+	return digital_disabled;
 }
 
-boolean S_MIDIMusicDisabled()
+boolean S_MIDIMusicDisabled(void)
 {
-	return (nomidimusic || music_disabled);
+	return midi_disabled;
 }
 
-boolean S_MusicDisabled()
+boolean S_MusicDisabled(void)
 {
-	return (
-		(nodigimusic && nomidimusic) ||
-		(music_disabled && digital_disabled) ||
-		(nodigimusic && music_disabled) ||
-		(nomidimusic && digital_disabled)
-	);
+	return (midi_disabled && digital_disabled);
 }
 
 boolean S_MusicPlaying(void)
@@ -1333,7 +1328,7 @@ static void S_UnloadMusic(void)
 
 static boolean S_PlayMusic(boolean looping)
 {
-	if (nodigimusic || digital_disabled)
+	if (S_DigMusicDisabled())
 		return false; // try midi
 
 	if (!I_PlaySong(looping))

--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -1151,6 +1151,43 @@ void S_StartSoundName(void *mo, const char *soundname)
 	S_StartSound(mo, soundnum);
 }
 
+//
+// Initializes sound stuff, including volume
+// Sets channels, SFX volume,
+//  allocates channel buffer, sets S_sfx lookup.
+//
+void S_InitSfxChannels(INT32 sfxVolume)
+{
+	INT32 i;
+
+	if (dedicated)
+		return;
+
+	S_SetSfxVolume(sfxVolume);
+
+	SetChannelsNum();
+
+	// Note that sounds have not been cached (yet).
+	for (i = 1; i < NUMSFX; i++)
+	{
+		S_sfx[i].usefulness = -1; // for I_GetSfx()
+		S_sfx[i].lumpnum = LUMPERROR;
+	}
+
+	// precache sounds if requested by cmdline, or precachesound var true
+	if (!nosound && (M_CheckParm("-precachesound") || precachesound.value))
+	{
+		// Initialize external data (all sounds) at start, keep static.
+		CONS_Printf(M_GetText("Loading sounds... "));
+
+		for (i = 1; i < NUMSFX; i++)
+			if (S_sfx[i].name)
+				S_sfx[i].data = I_GetSfx(&S_sfx[i]);
+
+		CONS_Printf(M_GetText(" pre-cached all sound data\n"));
+	}
+}
+
 /// ------------------------
 /// Music
 /// ------------------------
@@ -1177,10 +1214,7 @@ const char *compat_special_music_slots[16] =
 };
 #endif
 
-#define music_playing (music_name[0]) // String is empty if no music is playing
-
 static char      music_name[7]; // up to 6-character name
-static boolean   mus_paused     = 0;  // whether songs are mus_paused
 
 /// ------------------------
 /// Music Status
@@ -1203,6 +1237,29 @@ boolean S_MusicDisabled()
 		(music_disabled && digital_disabled) ||
 		(nodigimusic && music_disabled) ||
 		(nomidimusic && digital_disabled)
+	);
+}
+
+boolean S_MusicPlaying(void)
+{
+	return I_MusicPlaying();
+}
+
+boolean S_MusicPaused(void)
+{
+	return I_MusicPaused();
+}
+
+const char *S_MusicName(void)
+{
+	return music_name;
+}
+
+boolean S_MusicExists(const char *mname, boolean checkMIDI, boolean checkDigi)
+{
+	return (
+		(checkDigi ? W_CheckNumForName(va("O_%s", mname)) != LUMPERROR : false)
+		|| (checkMIDI ? W_CheckNumForName(va("D_%s", mname)) != LUMPERROR : false)
 	);
 }
 
@@ -1229,15 +1286,15 @@ static boolean S_LoadMusic(const char *mname)
 
 	if (S_DigMusicDisabled())
 	{
-		if (W_CheckNumForName(va("d_%s", mname)) == LUMPERROR)
+		if (!S_MIDIExists(mname))
 			return false;
 		mlumpnum = W_GetNumForName(va("d_%s", mname));
 	}
 	else
 	{
-		if (W_CheckNumForName(va("o_%s", mname)) != LUMPERROR)
+		if (S_DigExists(mname))
 			mlumpnum = W_GetNumForName(va("o_%s", mname));
-		else if (W_CheckNumForName(va("d_%s", mname)) != LUMPERROR)
+		else if (S_MIDIExists(mname))
 			mlumpnum = W_GetNumForName(va("d_%s", mname));
 		else
 			return false;
@@ -1326,10 +1383,10 @@ void S_ChangeMusic(const char *mmusic, UINT16 mflags, boolean looping)
 
 void S_StopMusic(void)
 {
-	if (!music_playing)
+	if (!I_MusicPlaying())
 		return;
 
-	if (mus_paused)
+	if (I_MusicPaused())
 		I_ResumeSong();
 
 	S_SpeedMusic(1.0f);
@@ -1341,6 +1398,31 @@ void S_StopMusic(void)
 #endif
 
 	music_name[0] = 0;
+}
+
+//
+// Stop and resume music, during game PAUSE.
+//
+void S_PauseAudio(void)
+{
+	if (I_MusicPlaying() && !I_MusicPaused())
+		I_PauseSong();
+
+	// pause cd music
+#if (defined (__unix__) && !defined (MSDOS)) || defined (UNIXCOMMON) || defined (HAVE_SDL)
+	I_PauseCD();
+#else
+	I_StopCD();
+#endif
+}
+
+void S_ResumeAudio(void)
+{
+	if (I_MusicPlaying() && I_MusicPaused())
+		I_ResumeSong();
+
+	// resume cd music
+	I_ResumeCD();
 }
 
 void S_SetMusicVolume(INT32 digvolume, INT32 seqvolume)
@@ -1355,7 +1437,7 @@ void S_SetMusicVolume(INT32 digvolume, INT32 seqvolume)
 	CV_SetValue(&cv_digmusicvolume, digvolume&31);
 	actualdigmusicvolume = cv_digmusicvolume.value;   //check for change of var
 
-	if (digvolume < 0 || digvolume > 31)
+	if (seqvolume < 0 || seqvolume > 31)
 		CONS_Alert(CONS_WARNING, "midimusicvolume should be between 0-31\n");
 	CV_SetValue(&cv_midimusicvolume, seqvolume&31);
 	actualmidimusicvolume = cv_midimusicvolume.value;   //check for change of var
@@ -1375,51 +1457,10 @@ void S_SetMusicVolume(INT32 digvolume, INT32 seqvolume)
 	}
 }
 
+
 /// ------------------------
 /// Init & Others
 /// ------------------------
-
-//
-// Initializes sound stuff, including volume
-// Sets channels, SFX and music volume,
-//  allocates channel buffer, sets S_sfx lookup.
-//
-void S_Init(INT32 sfxVolume, INT32 digMusicVolume, INT32 midiMusicVolume)
-{
-	INT32 i;
-
-	if (dedicated)
-		return;
-
-	S_SetSfxVolume(sfxVolume);
-	S_SetMusicVolume(digMusicVolume, midiMusicVolume);
-
-	SetChannelsNum();
-
-	// no sounds are playing, and they are not mus_paused
-	mus_paused = 0;
-
-	// Note that sounds have not been cached (yet).
-	for (i = 1; i < NUMSFX; i++)
-	{
-		S_sfx[i].usefulness = -1; // for I_GetSfx()
-		S_sfx[i].lumpnum = LUMPERROR;
-	}
-
-	// precache sounds if requested by cmdline, or precachesound var true
-	if (!nosound && (M_CheckParm("-precachesound") || precachesound.value))
-	{
-		// Initialize external data (all sounds) at start, keep static.
-		CONS_Printf(M_GetText("Loading sounds... "));
-
-		for (i = 1; i < NUMSFX; i++)
-			if (S_sfx[i].name)
-				S_sfx[i].data = I_GetSfx(&S_sfx[i]);
-
-		CONS_Printf(M_GetText(" pre-cached all sound data\n"));
-	}
-}
-
 
 //
 // Per level startup code.
@@ -1435,46 +1476,7 @@ void S_Start(void)
 		mapmusflags = (mapheaderinfo[gamemap-1]->mustrack & MUSIC_TRACKMASK);
 	}
 
-	mus_paused = 0;
-
 	if (cv_resetmusic.value)
 		S_StopMusic();
 	S_ChangeMusic(mapmusname, mapmusflags, true);
-}
-
-//
-// Stop and resume music, during game PAUSE.
-//
-void S_PauseAudio(void)
-{
-	if (!nodigimusic)
-		I_PauseSong();
-
-	if (music_playing && !mus_paused)
-	{
-		I_PauseSong();
-		mus_paused = true;
-	}
-
-	// pause cd music
-#if (defined (__unix__) && !defined (MSDOS)) || defined (UNIXCOMMON) || defined (HAVE_SDL)
-	I_PauseCD();
-#else
-	I_StopCD();
-#endif
-}
-
-void S_ResumeAudio(void)
-{
-	if (!nodigimusic)
-		I_ResumeSong();
-	else
-	if (music_playing && mus_paused)
-	{
-		I_ResumeSong();
-		mus_paused = false;
-	}
-
-	// resume cd music
-	I_ResumeCD();
 }

--- a/src/s_sound.h
+++ b/src/s_sound.h
@@ -108,7 +108,7 @@ boolean S_MusicDisabled(void);
 boolean S_MusicPlaying(void);
 boolean S_MusicPaused(void);
 musictype_t S_MusicType(void);
-const char *S_MusicName(void);
+boolean S_MusicInfo(char *mname, UINT16 *mflags, boolean *looping);
 boolean S_MusicExists(const char *mname, boolean checkMIDI, boolean checkDigi);
 #define S_DigExists(a) S_MusicExists(a, false, true)
 #define S_MIDIExists(a) S_MusicExists(a, true, false)

--- a/src/s_sound.h
+++ b/src/s_sound.h
@@ -14,6 +14,7 @@
 #ifndef __S_SOUND__
 #define __S_SOUND__
 
+#include "i_sound.h" // musictype_t
 #include "sounds.h"
 #include "m_fixed.h"
 #include "command.h"
@@ -106,6 +107,7 @@ boolean S_MIDIMusicDisabled(void);
 boolean S_MusicDisabled(void);
 boolean S_MusicPlaying(void);
 boolean S_MusicPaused(void);
+musictype_t S_MusicType(void);
 const char *S_MusicName(void);
 boolean S_MusicExists(const char *mname, boolean checkMIDI, boolean checkDigi);
 #define S_DigExists(a) S_MusicExists(a, false, true)

--- a/src/s_sound.h
+++ b/src/s_sound.h
@@ -69,9 +69,9 @@ void S_RegisterSoundStuff(void);
 
 //
 // Initializes sound stuff, including volume
-// Sets channels, SFX and music volume, allocates channel buffer, sets S_sfx lookup.
+// Sets channels, SFX, allocates channel buffer, sets S_sfx lookup.
 //
-void S_Init(INT32 sfxVolume, INT32 digMusicVolume, INT32 midiMusicVolume);
+void S_InitSfxChannels(INT32 sfxVolume);
 
 //
 // Per level startup code.
@@ -101,9 +101,16 @@ void S_StopSound(void *origin);
 // Music Status
 //
 
-boolean S_DigMusicDisabled();
-boolean S_MIDIMusicDisabled();
-boolean S_MusicDisabled();
+boolean S_DigMusicDisabled(void);
+boolean S_MIDIMusicDisabled(void);
+boolean S_MusicDisabled(void);
+boolean S_MusicPlaying(void);
+boolean S_MusicPaused(void);
+const char *S_MusicName(void);
+boolean S_MusicExists(const char *mname, boolean checkMIDI, boolean checkDigi);
+#define S_DigExists(a) S_MusicExists(a, false, true)
+#define S_MIDIExists(a) S_MusicExists(a, true, false)
+
 
 //
 // Music Properties

--- a/src/s_sound.h
+++ b/src/s_sound.h
@@ -97,15 +97,31 @@ void S_StartSoundAtVolume(const void *origin, sfxenum_t sound_id, INT32 volume);
 // Stop sound for thing at <origin>
 void S_StopSound(void *origin);
 
+//
+// Music Status
+//
+
+boolean S_DigMusicDisabled();
+boolean S_MIDIMusicDisabled();
+boolean S_MusicDisabled();
+
+//
+// Music Properties
+//
+
+// Set Speed of Music
+boolean S_SpeedMusic(float speed);
+
+//
+// Music Routines
+//
+
 // Start music track, arbitrary, given its name, and set whether looping
 // note: music flags 12 bits for tracknum (gme, other formats with more than one track)
 //       13-15 aren't used yet
 //       and the last bit we ignore (internal game flag for resetting music on reload)
 #define S_ChangeMusicInternal(a,b) S_ChangeMusic(a,0,b)
 void S_ChangeMusic(const char *mmusic, UINT16 mflags, boolean looping);
-
-// Set Speed of Music
-boolean S_SpeedMusic(float speed);
 
 // Stops the music.
 void S_StopMusic(void);
@@ -121,9 +137,11 @@ void S_UpdateSounds(void);
 
 FUNCMATH fixed_t S_CalculateSoundDistance(fixed_t px1, fixed_t py1, fixed_t pz1, fixed_t px2, fixed_t py2, fixed_t pz2);
 
-void S_SetDigMusicVolume(INT32 volume);
-void S_SetMIDIMusicVolume(INT32 volume);
 void S_SetSfxVolume(INT32 volume);
+void S_SetMusicVolume(INT32 digvolume, INT32 seqvolume);
+#define S_SetDigMusicVolume(a) S_SetMusicVolume(a,-1)
+#define S_SetMIDIMusicVolume(a) S_SetMusicVolume(-1,a)
+#define S_InitMusicVolume() S_SetMusicVolume(-1,-1)
 
 INT32 S_OriginPlaying(void *origin);
 INT32 S_IdPlaying(sfxenum_t id);

--- a/src/sdl/i_video.c
+++ b/src/sdl/i_video.c
@@ -566,7 +566,7 @@ static void Impl_HandleWindowEvent(SDL_WindowEvent evt)
 		// Tell game we got focus back, resume music if necessary
 		window_notinfocus = false;
 		if (!paused)
-			I_ResumeSong(0); //resume it
+			I_ResumeSong(); //resume it
 
 		if (!firsttimeonmouse)
 		{
@@ -578,7 +578,7 @@ static void Impl_HandleWindowEvent(SDL_WindowEvent evt)
 	{
 		// Tell game we lost focus, pause music
 		window_notinfocus = true;
-		I_PauseSong(0);
+		I_PauseSong();
 
 		if (!disable_mouse)
 		{

--- a/src/sdl/mixer_sound.c
+++ b/src/sdl/mixer_sound.c
@@ -719,8 +719,9 @@ boolean I_PlaySong(boolean looping)
 		Mix_HookMusic(mix_gme, gme);
 		return true;
 	}
+	else
 #endif
-	else if (!music)
+	if (!music)
 		return false;
 
 	if (Mix_PlayMusic(music, looping && loop_point == 0.0f ? -1 : 0) == -1)

--- a/src/sdl/mixer_sound.c
+++ b/src/sdl/mixer_sound.c
@@ -503,7 +503,7 @@ void I_ShutdownMusic(void)
 /// Music Properties
 /// ------------------------
 
-musictype_t I_MusicType(void)
+musictype_t I_SongType(void)
 {
 #ifdef HAVE_LIBGME
 	if (gme)
@@ -522,12 +522,12 @@ musictype_t I_MusicType(void)
 		return (musictype_t)Mix_GetMusicType(music);
 }
 
-boolean I_MusicPlaying(void)
+boolean I_SongPlaying(void)
 {
 	return (boolean)music;
 }
 
-boolean I_MusicPaused(void)
+boolean I_SongPaused(void)
 {
 	return songpaused;
 }
@@ -772,7 +772,7 @@ void I_SetMusicVolume(UINT8 volume)
 		return;
 
 #ifdef _WIN32
-	if (I_MusicType() == MU_MID)
+	if (I_SongType() == MU_MID)
 		// HACK: Until we stop using native MIDI,
 		// disable volume changes
 		music_volume = 31;

--- a/src/sdl/mixer_sound.c
+++ b/src/sdl/mixer_sound.c
@@ -63,7 +63,7 @@
 UINT8 sound_started = false;
 
 static Mix_Music *music;
-static UINT8 music_volume, midi_volume, sfx_volume;
+static UINT8 music_volume, sfx_volume;
 static float loop_point;
 static boolean songpaused;
 
@@ -91,7 +91,7 @@ void I_StartupSound(void)
 	}
 
 	music = NULL;
-	music_volume = midi_volume = sfx_volume = 0;
+	music_volume = sfx_volume = 0;
 
 #if SDL_MIXER_VERSION_ATLEAST(1,2,11)
 	Mix_Init(MIX_INIT_FLAC|MIX_INIT_MOD|MIX_INIT_MP3|MIX_INIT_OGG);

--- a/src/sdl/mixer_sound.c
+++ b/src/sdl/mixer_sound.c
@@ -656,7 +656,6 @@ boolean I_LoadSong(char *data, size_t len)
 	{
 		gme_equalizer_t eq = {GME_TREBLE, GME_BASS, 0,0,0,0,0,0,0,0};
 		gme_set_equalizer(gme, &eq);
-		Mix_HookMusic(mix_gme, gme);
 		return true;
 	}
 #endif
@@ -712,16 +711,17 @@ void I_UnloadSong(void)
 
 boolean I_PlaySong(boolean looping)
 {
-	if (!music)
-		return false;
-#ifdef HAVE_GME
+#ifdef HAVE_LIBGME
 	if (gme)
 	{
 		gme_start_track(gme, 0);
 		current_track = 0;
+		Mix_HookMusic(mix_gme, gme);
 		return true;
 	}
 #endif
+	else if (!music)
+		return false;
 
 	if (Mix_PlayMusic(music, looping && loop_point == 0.0f ? -1 : 0) == -1)
 	{

--- a/src/sdl/mixer_sound.c
+++ b/src/sdl/mixer_sound.c
@@ -769,7 +769,7 @@ void I_ResumeSong(void)
 
 void I_SetMusicVolume(UINT8 volume)
 {
-	if (!music)
+	if (!I_SongPlaying())
 		return;
 
 #ifdef _WIN32

--- a/src/sdl/mixer_sound.c
+++ b/src/sdl/mixer_sound.c
@@ -524,7 +524,12 @@ musictype_t I_SongType(void)
 
 boolean I_SongPlaying(void)
 {
-	return (boolean)music;
+	return (
+#ifdef HAVE_LIBGME
+		(I_SongType() == MU_GME && gme) ||
+#endif
+		(boolean)music
+	);
 }
 
 boolean I_SongPaused(void)

--- a/src/sdl/mixer_sound.c
+++ b/src/sdl/mixer_sound.c
@@ -453,6 +453,16 @@ musictype_t I_GetMusicType(void)
 		return (musictype_t)Mix_GetMusicType(music);
 }
 
+boolean I_MusicPlaying(void)
+{
+	return (boolean)music;
+}
+
+boolean I_MusicPaused(void)
+{
+	return songpaused;
+}
+
 // Music hooks
 static void music_loop(void)
 {

--- a/src/sdl/mixer_sound.c
+++ b/src/sdl/mixer_sound.c
@@ -705,8 +705,11 @@ boolean I_LoadSong(char *data, size_t len)
 
 void I_UnloadSong(void)
 {
-	Mix_FreeMusic(music);
-	music = NULL;
+	// \todo unhook looper
+	//var_cleanup();
+	//Mix_FreeMusic(music);
+	//music = NULL;
+	I_StopSong();
 }
 
 boolean I_PlaySong(boolean looping)

--- a/src/sdl/mixer_sound.c
+++ b/src/sdl/mixer_sound.c
@@ -566,7 +566,11 @@ boolean I_LoadSong(char *data, size_t len)
 	const size_t key3len = strlen(key3);
 	char *p = data;
 
-	if (music || gme)
+	if (music
+#ifdef HAVE_LIBGME
+		|| gme
+#endif
+	)
 		I_UnloadSong();
 
 #ifdef HAVE_LIBGME

--- a/src/sdl/mixer_sound.c
+++ b/src/sdl/mixer_sound.c
@@ -35,7 +35,7 @@
 #endif
 
 // thanks alam for making the buildbots happy!
-#if SDL_MIXER_VERSION_ATLEAST(2,0,3)
+#if SDL_MIXER_VERSION_ATLEAST(2,0,2)
 #define MUS_MP3_MAD MUS_MP3_MAD_UNUSED
 #define MUS_MODPLUG MUS_MODPLUG_UNUSED
 #endif

--- a/src/sdl/mixer_sound.c
+++ b/src/sdl/mixer_sound.c
@@ -34,6 +34,12 @@
 	(SDL_MIXER_COMPILEDVERSION >= SDL_VERSIONNUM(X, Y, Z))
 #endif
 
+// thanks alam for making the buildbots happy!
+#if SDL_MIXER_VERSION_ATLEAST(2,0,3)
+#define MUS_MP3_MAD MUS_MP3_MAD_UNUSED
+#define MUS_MODPLUG MUS_MODPLUG_UNUSED
+#endif
+
 #ifdef HAVE_LIBGME
 #include "gme/gme.h"
 #define GME_TREBLE 5.0
@@ -501,17 +507,9 @@ musictype_t I_SongType(void)
 		return MU_NONE;
 	else if (Mix_GetMusicType(music) == MUS_MID)
 		return MU_MID;
-	else if (Mix_GetMusicType(music) == MUS_MOD
-#if SDL_MIXER_VERSION_ATLEAST(2,0,3)
-		|| Mix_GetMusicType(music) == MUS_MODPLUG_UNUSED
-#endif
-	)
+	else if (Mix_GetMusicType(music) == MUS_MOD || Mix_GetMusicType(music) == MUS_MODPLUG)
 		return MU_MOD;
-	else if (Mix_GetMusicType(music) == MUS_MP3
-#if SDL_MIXER_VERSION_ATLEAST(2,0,3)
-		|| Mix_GetMusicType(music) == MUS_MP3_MAD_UNUSED
-#endif
-	)
+	else if (Mix_GetMusicType(music) == MUS_MP3 || Mix_GetMusicType(music) == MUS_MP3_MAD)
 		return MU_MP3;
 	else
 		return (musictype_t)Mix_GetMusicType(music);

--- a/src/sdl/mixer_sound.c
+++ b/src/sdl/mixer_sound.c
@@ -82,7 +82,10 @@ void I_StartupSound(void)
 
 	// EE inits audio first so we're following along.
 	if (SDL_WasInit(SDL_INIT_AUDIO) == SDL_INIT_AUDIO)
-		CONS_Printf("SDL Audio already started\n");
+	{
+		CONS_Debug(DBG_DETAILED, "SDL Audio already started\n");
+		return;
+	}
 	else if (SDL_InitSubSystem(SDL_INIT_AUDIO) < 0)
 	{
 		CONS_Alert(CONS_ERROR, "Error initializing SDL Audio: %s\n", SDL_GetError());

--- a/src/sdl/mixer_sound.c
+++ b/src/sdl/mixer_sound.c
@@ -501,9 +501,17 @@ musictype_t I_SongType(void)
 		return MU_NONE;
 	else if (Mix_GetMusicType(music) == MUS_MID)
 		return MU_MID;
-	else if (Mix_GetMusicType(music) == MUS_MOD || Mix_GetMusicType(music) == MUS_MODPLUG_UNUSED)
+	else if (Mix_GetMusicType(music) == MUS_MOD
+#if SDL_MIXER_VERSION_ATLEAST(2,0,3)
+		|| Mix_GetMusicType(music) == MUS_MODPLUG_UNUSED
+#endif
+	)
 		return MU_MOD;
-	else if (Mix_GetMusicType(music) == MUS_MP3 || Mix_GetMusicType(music) == MUS_MP3_MAD_UNUSED)
+	else if (Mix_GetMusicType(music) == MUS_MP3
+#if SDL_MIXER_VERSION_ATLEAST(2,0,3)
+		|| Mix_GetMusicType(music) == MUS_MP3_MAD_UNUSED
+#endif
+	)
 		return MU_MP3;
 	else
 		return (musictype_t)Mix_GetMusicType(music);
@@ -552,6 +560,14 @@ boolean I_SetSongSpeed(float speed)
 
 boolean I_LoadSong(char *data, size_t len)
 {
+	const char *key1 = "LOOP";
+	const char *key2 = "POINT=";
+	const char *key3 = "MS=";
+	const size_t key1len = strlen(key1);
+	const size_t key2len = strlen(key2);
+	const size_t key3len = strlen(key3);
+	char *p = data;
+
 	if (music || gme)
 		I_UnloadSong();
 
@@ -660,13 +676,6 @@ boolean I_LoadSong(char *data, size_t len)
 	// Find the OGG loop point.
 	loop_point = 0.0f;
 
-	const char *key1 = "LOOP";
-	const char *key2 = "POINT=";
-	const char *key3 = "MS=";
-	const size_t key1len = strlen(key1);
-	const size_t key2len = strlen(key2);
-	const size_t key3len = strlen(key3);
-	char *p = data;
 	while ((UINT32)(p - data) < len)
 	{
 		if (strncmp(p++, key1, key1len))

--- a/src/sdl/mixer_sound.c
+++ b/src/sdl/mixer_sound.c
@@ -476,10 +476,6 @@ static void mix_gme(void *udata, Uint8 *stream, int len)
 
 FUNCMATH void I_InitMusic(void)
 {
-#ifdef HAVE_LIBGME
-	gme = NULL;
-	current_track = -1;
-#endif
 }
 
 void I_ShutdownMusic(void)

--- a/src/sdl/sdl_sound.c
+++ b/src/sdl/sdl_sound.c
@@ -1336,6 +1336,16 @@ musictype_t I_GetMusicType(void)
 #endif
 }
 
+boolean I_MusicPlaying(void)
+{
+	return music_started;
+}
+
+boolean I_MusicPaused(void)
+{
+	return Mix_PausedMusic();
+}
+
 #ifdef HAVE_LIBGME
 static void I_ShutdownGMEMusic(void)
 {

--- a/src/sdl/sdl_sound.c
+++ b/src/sdl/sdl_sound.c
@@ -1702,7 +1702,7 @@ boolean I_LoadSong(char *data, size_t len)
 	return false;
 }
 
-void I_SetMIDIMusicVolume(UINT8 volume)
+void I_SetMusicVolume(UINT8 volume)
 {
 #ifdef HAVE_MIXER
 	if ((nomidimusic && nodigimusic) || !musicStarted)
@@ -1949,11 +1949,6 @@ static void I_StopGME(void)
 	gme_seek(localdata.gme_emu, 0);
 	Snd_UnlockAudio();
 #endif
-}
-
-void I_SetDigMusicVolume(UINT8 volume)
-{
-	I_SetMIDIMusicVolume(volume);
 }
 
 boolean I_SetSongSpeed(float speed)

--- a/src/sdl/sdl_sound.c
+++ b/src/sdl/sdl_sound.c
@@ -1313,7 +1313,7 @@ void I_StartupSound(void)
 // MUSIC API.
 //
 
-musictype_t I_MusicType(void)
+musictype_t I_SongType(void)
 {
 #ifdef HAVE_MIXER
 #ifdef HAVE_LIBGME
@@ -1336,12 +1336,12 @@ musictype_t I_MusicType(void)
 #endif
 }
 
-boolean I_MusicPlaying(void)
+boolean I_SongPlaying(void)
 {
 	return music_started;
 }
 
-boolean I_MusicPaused(void)
+boolean I_SongPaused(void)
 {
 	return Mix_PausedMusic();
 }
@@ -1591,17 +1591,17 @@ void I_ShutdownMusic(void)
 //  MUSIC PROPERTIES
 /// ------------------------
 
-musictype_t I_MusicType(void)
+musictype_t I_SongType(void)
 {
 	return MU_NONE;
 }
 
-boolean I_MusicPlaying(void)
+boolean I_SongPlaying(void)
 {
 	return false;
 }
 
-boolean I_MusicPaused(void)
+boolean I_SongPaused(void)
 {
 	return false;
 }

--- a/src/sdl/sdl_sound.c
+++ b/src/sdl/sdl_sound.c
@@ -1605,7 +1605,7 @@ static void I_PauseGME(void)
 #endif
 }
 
-void I_PauseSong(INT32 handle)
+void I_PauseSong(void)
 {
 	(void)handle;
 	I_PauseGME();
@@ -1625,7 +1625,7 @@ static void I_ResumeGME(void)
 #endif
 }
 
-void I_ResumeSong(INT32 handle)
+void I_ResumeSong(void)
 {
 	(void)handle;
 	I_ResumeGME();
@@ -1669,7 +1669,7 @@ void I_UnRegisterSong(INT32 handle)
 #endif
 }
 
-INT32 I_RegisterSong(void *data, size_t len)
+boolean I_LoadSong(char *data, size_t len)
 {
 #ifdef HAVE_MIXER
 	if (nomidimusic || !musicStarted)

--- a/src/sdl/sdl_sound.c
+++ b/src/sdl/sdl_sound.c
@@ -989,7 +989,7 @@ FUNCINLINE static ATTRINLINE void I_UpdateStream16M(Uint8 *stream, int len)
 	if (Snd_Mutex) SDL_UnlockMutex(Snd_Mutex);
 }
 
-#ifdef HAVE_LIBGME
+#if 0 //#ifdef HAVE_LIBGME
 static void I_UpdateSteamGME(Music_Emu *emu, INT16 *stream, int len, UINT8 looping)
 {
 	#define GME_BUFFER_LEN 44100*2048
@@ -1049,14 +1049,16 @@ static void SDLCALL I_UpdateStream(void *userdata, Uint8 *stream, int len)
 	else if (audio.channels == 2 && audio.format == AUDIO_S16SYS)
 	{
 		I_UpdateStream16S(stream, len);
-#ifdef HAVE_LIBGME
-		if (userdata)
-		{
-			srb2audio_t *sa_userdata = userdata;
-			if (!sa_userdata->gme_pause)
-				I_UpdateSteamGME(sa_userdata->gme_emu, (INT16 *)stream, len/4, sa_userdata->gme_loop);
-		}
-#endif
+
+		// Crashes! But no matter; this build doesn't play music anyway...
+// #ifdef HAVE_LIBGME
+// 		if (userdata)
+// 		{
+// 			srb2audio_t *sa_userdata = userdata;
+// 			if (!sa_userdata->gme_pause)
+// 				I_UpdateSteamGME(sa_userdata->gme_emu, (INT16 *)stream, len/4, sa_userdata->gme_loop);
+// 		}
+// #endif
 
 	}
 }
@@ -1313,40 +1315,11 @@ void I_StartupSound(void)
 // MUSIC API.
 //
 
-musictype_t I_SongType(void)
-{
-#ifdef HAVE_MIXER
-#ifdef HAVE_LIBGME
-	if (gme)
-		return MU_GME;
-	else
-#endif
-	if (!music)
-		return MU_NONE;
-	else if (Mix_GetMusicType(music) == MUS_MID)
-		return MU_MID;
-	else if (Mix_GetMusicType(music) == MUS_MOD || Mix_GetMusicType(music) == MUS_MODPLUG_UNUSED)
-		return MU_MOD;
-	else if (Mix_GetMusicType(music) == MUS_MP3 || Mix_GetMusicType(music) == MUS_MP3_MAD_UNUSED)
-		return MU_MP3;
-	else
-		return (musictype_t)Mix_GetMusicType(music);
-#else
-	return MU_NONE
-#endif
-}
+/// ------------------------
+//  MUSIC SYSTEM
+/// ------------------------
 
-boolean I_SongPlaying(void)
-{
-	return music_started;
-}
-
-boolean I_SongPaused(void)
-{
-	return Mix_PausedMusic();
-}
-
-#ifdef HAVE_LIBGME
+#if 0 //#ifdef HAVE_LIBGME
 static void I_ShutdownGMEMusic(void)
 {
 	Snd_LockAudio();
@@ -1357,235 +1330,14 @@ static void I_ShutdownGMEMusic(void)
 }
 #endif
 
-#ifdef HAVE_MIXER
-static boolean LoadSong(void *data, size_t lumplength, size_t selectpos)
-{
-	FILE *midfile;
-	const char *tempname;
-#ifdef USE_RWOPS
-	if (canuseRW)
-	{
-		SDL_RWops *SDLRW;
-		void *olddata = Smidi[selectpos]; //quick shortcut to set
-
-		Z_Free(olddata); //free old memory
-		Smidi[selectpos] = NULL;
-
-		if (!data)
-			return olddata != NULL; //was there old data?
-
-		SDLRW = SDL_RWFromConstMem(data, (int)lumplength); //new RWops from Z_zone
-		if (!SDLRW) //ERROR while making RWops!
-		{
-			CONS_Printf(M_GetText("Couldn't load music lump: %s\n"), SDL_GetError());
-			Z_Free(data);
-			return false;
-		}
-
-		music[selectpos] = Mix_LoadMUS_RW(SDLRW); // new Mix_Chuck from RWops
-		if (music[selectpos])
-			Smidi[selectpos] = data; //all done
-		else //ERROR while making Mix_Chuck
-		{
-			CONS_Printf(M_GetText("Couldn't load music data: %s\n"), Mix_GetError());
-			Z_Free(data);
-			SDL_RWclose(SDLRW);
-			Smidi[selectpos] = NULL;
-		}
-		return true;
-	}
-#endif
-	tempname = va("%s/%s", MIDI_PATH, fmidi[selectpos]);
-
-	if (!data)
-	{
-		if (FIL_FileExists(tempname))
-			return unlink(tempname)+1;
-#ifdef MIDI_PATH2
-		else if (FIL_FileExists(tempname = va("%s/%s", MIDI_PATH2, fmidi[selectpos])))
-			return unlink(tempname)+1;
-#endif
-		else
-			return false;
-	}
-
-	midfile = fopen(tempname, "wb");
-
-#ifdef MIDI_PATH2
-	if (!midfile)
-	{
-		tempname = va("%s/%s", MIDI_PATH2, fmidi[selectpos]);
-		midfile = fopen(tempname, "wb");
-	}
-#endif
-
-	if (!midfile)
-	{
-		CONS_Printf(M_GetText("Couldn't open file %s to write music in\n"), tempname);
-		Z_Free(data);
-		return false;
-	}
-
-	if (fwrite(data, lumplength, 1, midfile) == 0)
-	{
-		CONS_Printf(M_GetText("Couldn't write music into file %s because %s\n"), tempname, strerror(ferror(midfile)));
-		Z_Free(data);
-		fclose(midfile);
-		return false;
-	}
-
-	fclose(midfile);
-
-	Z_Free(data);
-
-	music[selectpos] = Mix_LoadMUS(tempname);
-	if (!music[selectpos]) //ERROR while making Mix_Chuck
-	{
-		CONS_Printf(M_GetText("Couldn't load music file %s: %s\n"), tempname, Mix_GetError());
-		return false;
-	}
-	return true;
-}
-#endif
-
-/// ------------------------
-//  MUSIC SYSTEM
-/// ------------------------
-
 void I_InitMusic(void)
 {
-#ifdef HAVE_MIXER
-	char ad[100];
-	SDL_version MIXcompiled;
-	const SDL_version *MIXlinked;
-#ifdef MIXER_INIT
-	const int mixstart = MIX_INIT_OGG;
-	int mixflags;
-#endif
-#endif
-#ifdef HAVE_LIBGME
+#if 0 //#ifdef HAVE_LIBGME
 	I_AddExitFunc(I_ShutdownGMEMusic);
 #endif
-
-#ifdef HAVE_MIXER
-	MIX_VERSION(&MIXcompiled)
-	MIXlinked = Mix_Linked_Version();
-	I_OutputMsg("Compiled for SDL_mixer version: %d.%d.%d\n",
-	            MIXcompiled.major, MIXcompiled.minor, MIXcompiled.patch);
-#ifdef MIXER_POS
-	if (MIXlinked->major == 1 && MIXlinked->minor == 2 && MIXlinked->patch < 7)
-		canlooping = SDL_FALSE;
-#endif
-#ifdef USE_RWOPS
-	if (M_CheckParm("-noRW"))
-		canuseRW = SDL_FALSE;
-#endif
-	I_OutputMsg("Linked with SDL_mixer version: %d.%d.%d\n",
-	            MIXlinked->major, MIXlinked->minor, MIXlinked->patch);
-	if (audio.freq < 44100 && !M_CheckParm ("-freq")) //I want atleast 44Khz
-	{
-		audio.samples = (Uint16)(audio.samples*(INT32)(44100/audio.freq));
-		audio.freq = 44100; //Alam: to keep it around the same XX ms
-	}
-
-	if (sound_started
-#ifdef HW3SOUND
-		&& hws_mode == HWS_DEFAULT_MODE
-#endif
-		)
-	{
-		I_OutputMsg("Temp Shutdown of SDL Audio System");
-		SDL_CloseAudio();
-		I_OutputMsg(" Done\n");
-	}
-
-	CONS_Printf("%s", M_GetText("I_InitMusic:"));
-
-#ifdef MIXER_INIT
-	mixflags = Mix_Init(mixstart);
-	if ((mixstart & MIX_INIT_FLAC) != (mixflags & MIX_INIT_FLAC))
-	{
-		CONS_Printf("%s", M_GetText(" Unable to load FLAC support\n"));
-	}
-	if ((mixstart & MIX_INIT_MOD ) != (mixflags & MIX_INIT_MOD ))
-	{
-		CONS_Printf("%s", M_GetText(" Unable to load MOD support\n"));
-	}
-	if ((mixstart & MIX_INIT_MP3 ) != (mixflags & MIX_INIT_MP3 ))
-	{
-		CONS_Printf("%s", M_GetText(" Unable to load MP3 support\n"));
-	}
-	if ((mixstart & MIX_INIT_OGG ) != (mixflags & MIX_INIT_OGG ))
-	{
-		CONS_Printf("%s", M_GetText(" Unable to load OGG support\n"));
-	}
-#endif
-
-	if (Mix_OpenAudio(audio.freq, audio.format, audio.channels, audio.samples) < 0) //open_music(&audio)
-	{
-		CONS_Printf(M_GetText(" Unable to open music: %s\n"), Mix_GetError());
-		midi_disabled = digital_disabled = true;
-		if (sound_started
-#ifdef HW3SOUND
-			&& hws_mode == HWS_DEFAULT_MODE
-#endif
-			)
-		{
-			if (SDL_OpenAudio(&audio, NULL) < 0) //retry
-			{
-				CONS_Printf("%s", M_GetText(" couldn't open audio with desired format\n"));
-				sound_disabled = true;
-				sound_started = false;
-			}
-			else
-			{
-				CONS_Printf(M_GetText(" Starting with audio driver : %s\n"), SDL_AudioDriverName(ad, (int)sizeof ad));
-			}
-		}
-		return;
-	}
-	else
-		CONS_Printf(M_GetText(" Starting up with audio driver : %s with SDL_Mixer\n"), SDL_AudioDriverName(ad, (int)sizeof ad));
-
-	samplecount = audio.samples;
-	CV_SetValue(&cv_samplerate, audio.freq);
-	if (sound_started
-#ifdef HW3SOUND
-		&& hws_mode == HWS_DEFAULT_MODE
-#endif
-		)
-		I_OutputMsg(" Reconfigured SDL Audio System");
-	else I_OutputMsg(" Configured SDL_Mixer System");
-	I_OutputMsg(" with %d samples/slice at %ikhz(%dms buffer)\n", samplecount, audio.freq/1000, (INT32) ((audio.samples * 1000.0f) / audio.freq));
-	Mix_SetPostMix(audio.callback, audio.userdata);  // after mixing music, add sound effects
-	Mix_Resume(-1);
-	CONS_Printf("%s", M_GetText("Music initialized\n"));
-	musicStarted = SDL_TRUE;
-	Msc_Mutex = SDL_CreateMutex();
-#endif
 }
 
-void I_ShutdownMusic(void)
-{
-#ifdef HAVE_MIXER
-	if ((midi_disabled && digital_disabled) || !musicStarted)
-		return;
-
-	CONS_Printf("%s", M_GetText("I_ShutdownMusic: "));
-
-	I_UnloadSong();
-	I_StopSong();
-	Mix_CloseAudio();
-#ifdef MIX_INIT
-	Mix_Quit();
-#endif
-	CONS_Printf("%s", M_GetText("shut down\n"));
-	musicStarted = SDL_FALSE;
-	if (Msc_Mutex)
-		SDL_DestroyMutex(Msc_Mutex);
-	Msc_Mutex = NULL;
-#endif
-}
+void I_ShutdownMusic(void) { }
 
 /// ------------------------
 //  MUSIC PROPERTIES
@@ -1618,149 +1370,64 @@ boolean I_SetSongSpeed(float speed)
 
 /// ------------------------
 //  MUSIC PLAYBACK
-//  \todo Merge Digital and MIDI
 /// ------------------------
+
+#if 0 //#ifdef HAVE_LIBGME
+static void I_StopGME(void)
+{
+	Snd_LockAudio();
+	gme_seek(localdata.gme_emu, 0);
+	Snd_UnlockAudio();
+}
+
+static void I_PauseGME(void)
+{
+	localdata.gme_pause = true;
+}
+
+static void I_ResumeGME(void)
+{
+	localdata.gme_pause = false;
+}
+#endif
 
 boolean I_LoadSong(char *data, size_t len)
 {
-#ifdef HAVE_MIXER
-	if (midi_disabled || !musicStarted)
-		return false;
-
-	if (!LoadSong(data, len, 0))
-		return false;
-
-	if (music[0])
-		return true;
-
-	CONS_Printf(M_GetText("Couldn't load MIDI: %s\n"), Mix_GetError());
-#else
-	(void)len;
-	(void)data;
-#endif
 	return false;
 }
 
-void I_UnloadSong(void)
-{
-#ifdef HAVE_MIXER
-
-	if (midi_disabled || !musicStarted)
-		return;
-
-	Mix_HaltMusic();
-	while (Mix_PlayingMusic())
-		;
-
-	if (music[handle])
-		Mix_FreeMusic(music[handle]);
-	music[handle] = NULL;
-	LoadSong(NULL, 0, handle);
-#else
-	(void)handle;
-#endif
-}
+void I_UnloadSong(void) { }
 
 boolean I_PlaySong(boolean looping)
 {
-#ifdef HAVE_MIXER
-	if (!musicStarted || !music[handle])
-		return false;
-
-#ifdef MIXER_POS
-	if (canlooping)
-		Mix_HookMusicFinished(NULL);
-#endif
-
-	if (Mix_FadeInMusic(music[handle], looping ? -1 : 0, MIDIfade) == -1)
-		CONS_Printf(M_GetText("Couldn't play song because %s\n"), Mix_GetError());
-	else
-	{
-		Mix_VolumeMusic(musicvol);
-		return true;
-	}
-#else
 	(void)looping;
-#endif
 	return false;
 }
 
 void I_StopSong(void)
 {
+#if 0 //#ifdef HAVE_LIBGME
 	I_StopGME();
-#ifdef HAVE_MIXER
-	if (digital_disabled)
-		return;
-
-#ifdef MIXER_POS
-	if (canlooping)
-		Mix_HookMusicFinished(NULL);
-#endif
-
-	Mix_HaltMusic();
-	while (Mix_PlayingMusic())
-		;
-
-	if (music[1])
-		Mix_FreeMusic(music[1]);
-	music[1] = NULL;
-	LoadSong(NULL, 0, 1);
-}
-
-static void I_PauseGME(void)
-{
-#ifdef HAVE_LIBGME
-	localdata.gme_pause = true;
 #endif
 }
 
 void I_PauseSong(void)
 {
-	(void)handle;
+#if 0 //#ifdef HAVE_LIBGME
 	I_PauseGME();
-#ifdef HAVE_MIXER
-	if ((midi_disabled && digital_disabled) || !musicStarted)
-		return;
-
-	Mix_PauseMusic();
-	//I_StopSong(handle);
-#endif
-}
-
-static void I_ResumeGME(void)
-{
-#ifdef HAVE_LIBGME
-	localdata.gme_pause = false;
 #endif
 }
 
 void I_ResumeSong(void)
 {
-	(void)handle;
+#if 0
 	I_ResumeGME();
-#ifdef HAVE_MIXER
-	if ((midi_disabled && digital_disabled) || !musicStarted)
-		return;
-
-	Mix_VolumeMusic(musicvol);
-	Mix_ResumeMusic();
-	//I_PlaySong(handle, true);
 #endif
 }
 
 void I_SetMusicVolume(UINT8 volume)
 {
-#ifdef HAVE_MIXER
-	if ((midi_disabled && digital_disabled) || !musicStarted)
-		return;
-
-	if (Msc_Mutex) SDL_LockMutex(Msc_Mutex);
-	musicvol = volume * 2;
-	if (Msc_Mutex) SDL_UnlockMutex(Msc_Mutex);
-	Mix_VolumeMusic(musicvol);
-#else
 	(void)volume;
-#endif
 }
 
 boolean I_SetSongTrack(int track)
@@ -1775,16 +1442,14 @@ boolean I_SetSongTrack(int track)
 //        then move to Playback section
 /// ------------------------
 
-#ifdef HAVE_LIBGME
+#if 0 //#ifdef HAVE_LIBGME
 static void I_CleanupGME(void *userdata)
 {
 	Z_Free(userdata);
 }
-#endif
 
 static boolean I_StartGMESong(const char *musicname, boolean looping)
 {
-#ifdef HAVE_LIBGME
 	char filename[9];
 	void *data;
 	lumpnum_t lumpnum;
@@ -1830,199 +1495,7 @@ static boolean I_StartGMESong(const char *musicname, boolean looping)
 	Snd_UnlockAudio();
 
 	return true;
-#else
-	(void)musicname;
-	(void)looping;
-#endif
-	return false;
-}
-
-boolean I_StartDigSong(const char *musicname, boolean looping)
-{
-#ifdef HAVE_MIXER
-	char filename[9];
-	void *data;
-	lumpnum_t lumpnum;
-	size_t lumplength;
-#endif
-
-	if(I_StartGMESong(musicname, looping))
-		return true;
-
-#ifdef HAVE_MIXER
-	if (digital_disabled)
-		return false;
-
-	snprintf(filename, sizeof filename, "o_%s", musicname);
-
-	lumpnum = W_CheckNumForName(filename);
-
-	I_StopSong();
-
-	if (lumpnum == LUMPERROR)
-	{
-		// Alam_GBC: like in win32/win_snd.c: Graue 02-29-2004: don't worry about missing music, there might still be a MIDI
-		//I_OutputMsg("Music lump %s not found!\n", filename);
-		return false; // No music found. Oh well!
-	}
-	else
-		lumplength = W_LumpLength(lumpnum);
-
-	data = W_CacheLumpNum(lumpnum, PU_MUSIC);
-
-	if (Msc_Mutex) SDL_LockMutex(Msc_Mutex);
-
-#ifdef MIXER_POS
-	if (canlooping && (loopingDig = looping) == SDL_TRUE && strcmp(data, "OggS")  == 0)
-		looping = false; // Only on looping Ogg files, will we will do our own looping
-
-	// Scan the Ogg Vorbis file for the COMMENT= field for a custom
-	// loop point
-	if (!looping && loopingDig)
-	{
-		size_t scan;
-		const char *dataum = data;
-		char looplength[64];
-		UINT32 loopstart = 0;
-		UINT8 newcount = 0;
-
-		Mix_HookMusicFinished(I_FinishMusic);
-
-		for (scan = 0; scan < lumplength; scan++)
-		{
-			if (*dataum++ == 'C'){
-			if (*dataum++ == 'O'){
-			if (*dataum++ == 'M'){
-			if (*dataum++ == 'M'){
-			if (*dataum++ == 'E'){
-			if (*dataum++ == 'N'){
-			if (*dataum++ == 'T'){
-			if (*dataum++ == '='){
-			if (*dataum++ == 'L'){
-			if (*dataum++ == 'O'){
-			if (*dataum++ == 'O'){
-			if (*dataum++ == 'P'){
-			if (*dataum++ == 'P'){
-			if (*dataum++ == 'O'){
-			if (*dataum++ == 'I'){
-			if (*dataum++ == 'N'){
-			if (*dataum++ == 'T'){
-			if (*dataum++ == '=')
-			{
-
-				while (*dataum != 1 && newcount != 63)
-					looplength[newcount++] = *dataum++;
-
-				looplength[newcount] = '\0';
-
-				loopstart = atoi(looplength);
-
-			}
-			else
-				dataum--;}
-			else
-				dataum--;}
-			else
-				dataum--;}
-			else
-				dataum--;}
-			else
-				dataum--;}
-			else
-				dataum--;}
-			else
-				dataum--;}
-			else
-				dataum--;}
-			else
-				dataum--;}
-			else
-				dataum--;}
-			else
-				dataum--;}
-			else
-				dataum--;}
-			else
-				dataum--;}
-			else
-				dataum--;}
-			else
-				dataum--;}
-			else
-				dataum--;}
-			else
-				dataum--;}
-		}
-
-		if (loopstart > 0)
-		{
-			loopstartDig = (double)((44.1l+loopstart) / 44100.0l); //8 PCM chucks off and PCM to secs
-//#ifdef PARANOIA
-			//I_OutputMsg("I_StartDigSong: setting looping point to %ul PCMs(%f seconds)\n", loopstart, loopstartDig);
-//#endif
-		}
-		else
-		{
-			looping = true; // loopingDig true, but couldn't find start loop point
-		}
-	}
-	else
-		loopstartDig = 0.0l;
-#else
-	if (looping && strcmp(data, "OggS")  == 0)
-		I_OutputMsg("I_StartDigSong: SRB2 was not compiled with looping music support(no Mix_FadeInMusicPos)\n");
-#endif
-
-	if (!LoadSong(data, lumplength, 1))
-	{
-		if (Msc_Mutex) SDL_UnlockMutex(Msc_Mutex);
-		return false;
-	}
-
-	// Note: LoadSong() frees the data. Let's make sure
-	// we don't try to use the data again.
-	data = NULL;
-
-	if (Mix_FadeInMusic(music[1], looping ? -1 : 0, Digfade) == -1)
-	{
-		if (Msc_Mutex) SDL_UnlockMutex(Msc_Mutex);
-		I_OutputMsg("I_StartDigSong: Couldn't play song %s because %s\n", musicname, Mix_GetError());
-		return false;
-	}
-	Mix_VolumeMusic(musicvol);
-
-	if (Msc_Mutex) SDL_UnlockMutex(Msc_Mutex);
-	return true;
-#else
-	(void)looping;
-	(void)musicname;
-	return false;
-#endif
-}
-
-static void I_StopGME(void)
-{
-#ifdef HAVE_LIBGME
-	Snd_LockAudio();
-	gme_seek(localdata.gme_emu, 0);
-	Snd_UnlockAudio();
-#endif
-}
-
-#ifdef MIXER_POS
-static void SDLCALL I_FinishMusic(void)
-{
-	if (!music[1])
-		return;
-	else if (Msc_Mutex) SDL_LockMutex(Msc_Mutex);
-//		I_OutputMsg("I_FinishMusic: Loopping song to %g seconds\n", loopstartDig);
-
-	if (Mix_FadeInMusicPos(music[1], loopstartDig ? 0 : -1, Digfade, loopstartDig) == 0)
-		Mix_VolumeMusic(musicvol);
-	else
-		I_OutputMsg("I_FinishMusic: Couldn't loop song because %s\n", Mix_GetError());
-
-	if (Msc_Mutex) SDL_UnlockMutex(Msc_Mutex);
 }
 #endif
+
 #endif //HAVE_SDL

--- a/src/win32/win_cd.c
+++ b/src/win32/win_cd.c
@@ -471,7 +471,7 @@ void I_PlayCD(UINT8 nTrack, UINT8 bLooping)
 	//faB: stop MIDI music, MIDI music will restart if volume is upped later
 	cv_digmusicvolume.value = 0;
 	cv_midimusicvolume.value = 0;
-	I_StopSong (0);
+	I_StopSong();
 
 	//faB: I don't use the notify message, I'm trying to minimize the delay
 	mciPlay.dwCallback = (DWORD)((size_t)hWndMain);

--- a/src/win32/win_main.c
+++ b/src/win32/win_main.c
@@ -110,9 +110,9 @@ static LRESULT CALLBACK MainWndproc(HWND hWnd, UINT message, WPARAM wParam, LPAR
 
 			// pause music when alt-tab
 			if (appActive  && !paused)
-				I_ResumeSong(0);
+				I_ResumeSong();
 			else if (!paused)
-				I_PauseSong(0);
+				I_PauseSong();
 			{
 				HANDLE ci = GetStdHandle(STD_INPUT_HANDLE);
 				DWORD mode;

--- a/src/win32/win_snd.c
+++ b/src/win32/win_snd.c
@@ -478,6 +478,19 @@ musictype_t I_GetMusicType(void)
 		return MU_NONE;
 }
 
+boolean I_MusicPlaying(void)
+{
+	return (boolean)music_stream;
+}
+
+boolean I_MusicPaused(void)
+{
+	boolean fmpaused = false;
+	if (music_stream)
+		FMOD_Channel_GetPaused(music_channel, &fmpaused);
+	return fmpaused;
+}
+
 void I_InitMusic(void)
 {
 }

--- a/src/win32/win_snd.c
+++ b/src/win32/win_snd.c
@@ -456,7 +456,7 @@ void I_ShutdownMusic(void)
 //  MUSIC PROPERTIES
 /// ------------------------
 
-musictype_t I_MusicType(void)
+musictype_t I_SongType(void)
 {
 #ifdef HAVE_LIBGME
 	if (gme)
@@ -491,12 +491,12 @@ musictype_t I_MusicType(void)
 		return MU_NONE;
 }
 
-boolean I_MusicPlaying(void)
+boolean I_SongPlaying(void)
 {
 	return (boolean)music_stream;
 }
 
-boolean I_MusicPaused(void)
+boolean I_SongPaused(void)
 {
 	boolean fmpaused = false;
 	if (music_stream)
@@ -780,7 +780,7 @@ boolean I_PlaySong(boolean looping)
 #endif
 
 	FMR(FMOD_System_PlaySound(fsys, FMOD_CHANNEL_FREE, music_stream, false, &music_channel));
-	if (I_MusicType() != MU_MID)
+	if (I_SongType() != MU_MID)
 		FMR(FMOD_Channel_SetVolume(music_channel, midi_volume / 31.0));
 	else
 		FMR(FMOD_Channel_SetVolume(music_channel, music_volume / 31.0));
@@ -822,7 +822,7 @@ void I_SetMusicVolume(UINT8 volume)
 		return;
 
 	// volume is 0 to 31.
-	if (I_MusicType() == MU_MID)
+	if (I_SongType() == MU_MID)
 		music_volume = 31; // windows bug hack
 	else
 		music_volume = volume;

--- a/src/win32/win_snd.c
+++ b/src/win32/win_snd.c
@@ -675,7 +675,6 @@ boolean I_LoadSong(char *data, size_t len)
 		fmt.decodebuffersize = (44100 * 2) / 35;
 		fmt.pcmreadcallback = GMEReadCallback;
 		fmt.userdata = gme;
-		FMR(FMOD_System_CreateStream(fsys, NULL, FMOD_OPENUSER | (looping ? FMOD_LOOP_NORMAL : 0), &fmt, &music_stream));
 		return true;
 	}
 #endif
@@ -772,6 +771,7 @@ boolean I_PlaySong(boolean looping)
 	{
 		gme_start_track(gme, 0);
 		current_track = 0;
+		FMR(FMOD_System_CreateStream(fsys, NULL, FMOD_OPENUSER | (looping ? FMOD_LOOP_NORMAL : 0), &fmt, &music_stream));
 		FMR(FMOD_System_PlaySound(fsys, FMOD_CHANNEL_FREE, music_stream, false, &music_channel));
 		FMR(FMOD_Channel_SetVolume(music_channel, music_volume / 31.0));
 		FMR(FMOD_Channel_SetPriority(music_channel, 0));

--- a/src/win32/win_snd.c
+++ b/src/win32/win_snd.c
@@ -713,14 +713,6 @@ boolean I_LoadSong(char *data, size_t len)
 	return true;
 }
 
-void I_SetDigMusicVolume(UINT8 volume)
-{
-	// volume is 0 to 31.
-	music_volume = volume;
-	if (I_GetMusicType() != MU_MID && music_stream)
-		FMR_MUSIC(FMOD_Channel_SetVolume(music_channel, volume / 31.0));
-}
-
 boolean I_SetSongSpeed(float speed)
 {
 	FMOD_RESULT e;
@@ -803,12 +795,18 @@ boolean I_SetSongTrack(INT32 track)
 // Fuck MIDI. ... Okay fine, you can have your silly D_-only mode.
 //
 
-void I_SetMIDIMusicVolume(UINT8 volume)
+void I_SetMusicVolume(UINT8 volume)
 {
+	if (!music_stream)
+		return;
+
 	// volume is 0 to 31.
-	midi_volume = volume;
-	if (I_GetMusicType() != MU_MID && music_stream)
-		FMR_MUSIC(FMOD_Channel_SetVolume(music_channel, volume / 31.0));
+	if (I_GetMusicType() == MU_MID)
+		music_volume = 31; // windows bug hack
+	else
+		music_volume = volume;
+
+	FMR_MUSIC(FMOD_Channel_SetVolume(music_channel, music_volume / 31.0));
 }
 
 boolean I_PlaySong(boolean looping)

--- a/src/win32/win_snd.c
+++ b/src/win32/win_snd.c
@@ -456,14 +456,14 @@ void I_ShutdownMusic(void)
 	I_ShutdownMIDIMusic();
 }
 
-void I_PauseSong(INT32 handle)
+void I_PauseSong(void)
 {
 	UNREFERENCED_PARAMETER(handle);
 	if (music_stream)
 		FMR_MUSIC(FMOD_Channel_SetPaused(music_channel, true));
 }
 
-void I_ResumeSong(INT32 handle)
+void I_ResumeSong(void)
 {
 	UNREFERENCED_PARAMETER(handle);
 	if (music_stream)
@@ -644,60 +644,64 @@ boolean I_StartDigSong(const char *musicname, boolean looping)
 	current_track = 0;
 
 	// Try to find a loop point in streaming music formats (ogg, mp3)
-	if (looping)
-	{
-		FMOD_RESULT e;
-		FMOD_TAG tag;
-		unsigned int loopstart, loopend;
+	FMOD_RESULT e;
+	FMOD_TAG tag;
+	unsigned int loopstart, loopend;
 
-		// A proper LOOPPOINT is its own tag, stupid.
-		e = FMOD_Sound_GetTag(music_stream, "LOOPPOINT", 0, &tag);
-		if (e != FMOD_ERR_TAGNOTFOUND)
+	// A proper LOOPPOINT is its own tag, stupid.
+	e = FMOD_Sound_GetTag(music_stream, "LOOPPOINT", 0, &tag);
+	if (e != FMOD_ERR_TAGNOTFOUND)
+	{
+		FMR(e);
+		loopstart = atoi((char *)tag.data); // assumed to be a string data tag.
+		FMR(FMOD_Sound_GetLoopPoints(music_stream, NULL, FMOD_TIMEUNIT_PCM, &loopend, FMOD_TIMEUNIT_PCM));
+		if (loopstart > 0)
+			FMR(FMOD_Sound_SetLoopPoints(music_stream, loopstart, FMOD_TIMEUNIT_PCM, loopend, FMOD_TIMEUNIT_PCM));
+		return true;
+	}
+
+	// todo
+	// if(music type == MIDI)
+	// {
+	// 	FMR(FMOD_Sound_SetMode(music_stream, FMOD_LOOP_NORMAL));
+	// 	return true;
+	// }
+
+	// Use LOOPMS for time in miliseconds.
+	e = FMOD_Sound_GetTag(music_stream, "LOOPMS", 0, &tag);
+	if (e != FMOD_ERR_TAGNOTFOUND)
+	{
+		FMR(e);
+		loopstart = atoi((char *)tag.data); // assumed to be a string data tag.
+		FMR(FMOD_Sound_GetLoopPoints(music_stream, NULL, FMOD_TIMEUNIT_MS, &loopend, FMOD_TIMEUNIT_PCM));
+		if (loopstart > 0)
+			FMR(FMOD_Sound_SetLoopPoints(music_stream, loopstart, FMOD_TIMEUNIT_MS, loopend, FMOD_TIMEUNIT_PCM));
+		return true;
+	}
+
+	// Try to fetch it from the COMMENT tag, like A.J. Freda
+	e = FMOD_Sound_GetTag(music_stream, "COMMENT", 0, &tag);
+	if (e != FMOD_ERR_TAGNOTFOUND)
+	{
+		char *loopText;
+		// Handle any errors that arose, first
+		FMR(e);
+		// Figure out where the number starts
+		loopText = strstr((char *)tag.data,"LOOPPOINT=");
+		if (loopText != NULL)
 		{
-			FMR(e);
-			loopstart = atoi((char *)tag.data); // assumed to be a string data tag.
+			// Skip the "LOOPPOINT=" part.
+			loopText += 10;
+			// Convert it to our looppoint
+			// FMOD seems to ensure the tag is properly NULL-terminated.
+			// atoi will stop when it reaches anything that's not a number.
+			loopstart = atoi(loopText);
+			// Now do the rest like above
 			FMR(FMOD_Sound_GetLoopPoints(music_stream, NULL, FMOD_TIMEUNIT_PCM, &loopend, FMOD_TIMEUNIT_PCM));
 			if (loopstart > 0)
 				FMR(FMOD_Sound_SetLoopPoints(music_stream, loopstart, FMOD_TIMEUNIT_PCM, loopend, FMOD_TIMEUNIT_PCM));
-			return true;
 		}
-
-		// Use LOOPMS for time in miliseconds.
-		e = FMOD_Sound_GetTag(music_stream, "LOOPMS", 0, &tag);
-		if (e != FMOD_ERR_TAGNOTFOUND)
-		{
-			FMR(e);
-			loopstart = atoi((char *)tag.data); // assumed to be a string data tag.
-			FMR(FMOD_Sound_GetLoopPoints(music_stream, NULL, FMOD_TIMEUNIT_MS, &loopend, FMOD_TIMEUNIT_PCM));
-			if (loopstart > 0)
-				FMR(FMOD_Sound_SetLoopPoints(music_stream, loopstart, FMOD_TIMEUNIT_MS, loopend, FMOD_TIMEUNIT_PCM));
-			return true;
-		}
-
-		// Try to fetch it from the COMMENT tag, like A.J. Freda
-		e = FMOD_Sound_GetTag(music_stream, "COMMENT", 0, &tag);
-		if (e != FMOD_ERR_TAGNOTFOUND)
-		{
-			char *loopText;
-			// Handle any errors that arose, first
-			FMR(e);
-			// Figure out where the number starts
-			loopText = strstr((char *)tag.data,"LOOPPOINT=");
-			if (loopText != NULL)
-			{
-				// Skip the "LOOPPOINT=" part.
-				loopText += 10;
-				// Convert it to our looppoint
-				// FMOD seems to ensure the tag is properly NULL-terminated.
-				// atoi will stop when it reaches anything that's not a number.
-				loopstart = atoi(loopText);
-				// Now do the rest like above
-				FMR(FMOD_Sound_GetLoopPoints(music_stream, NULL, FMOD_TIMEUNIT_PCM, &loopend, FMOD_TIMEUNIT_PCM));
-				if (loopstart > 0)
-					FMR(FMOD_Sound_SetLoopPoints(music_stream, loopstart, FMOD_TIMEUNIT_PCM, loopend, FMOD_TIMEUNIT_PCM));
-			}
-			return true;
-		}
+		return true;
 	}
 
 	// No special loop point, but we're playing so it's all good.
@@ -825,7 +829,7 @@ void I_SetMIDIMusicVolume(UINT8 volume)
 		FMR_MUSIC(FMOD_Channel_SetVolume(music_channel, volume / 31.0));
 }
 
-INT32 I_RegisterSong(void *data, size_t len)
+boolean I_PlaySong(boolean looping)
 {
 	FMOD_CREATESOUNDEXINFO fmt;
 	memset(&fmt, 0, sizeof(FMOD_CREATESOUNDEXINFO));


### PR DESCRIPTION
The music code was a freaking mess because it had different methods for digital and MIDI playback; redundant variables; and unclear separation for loading, playing, stopping, and unloading.

This is all internal plumbing, no user-facing changes (other than small sound menu tweaks.) Nothing that affects netsync because audio is not shared.

# Changes

* I combined all digital/MIDI methods
* `nomidimusic nodigimusic nosound` are merged into the existing variables `midi_disabled digital_disabled sound_disabled`
* I separated `S_Init` into `S_InitSfxChannels`
* I clearly separated playback and loading concerns
    * Internally, loading and playing a song are now called separately (`S_ChangeMusic` calls both)
    * Currently, stopping a song will also auto-unload it. I have plans to change this so that multiple music can be loaded at one time, but that's another MR.
    * `I_PlayDigSong` = `I_LoadSong` and `I_PlaySong`.
    * `I_StopDigSong` = `I_UnloadSong` and `I_StopSong`.
* New helper functions for music state
    * `I_SongType` - Returns format of music
    * `I_SongPlaying`
    * `I_SongPaused`
* New `s_sound` helper functions
    * `S_DigMusicDisabled`, `S_MIDIMusicDisabled`, `S_MusicDisabled`
    * `S_MusicPlaying`, `S_MusicPaused`, `S_MusicType`
    * `S_MusicInfo` - Returns current name, flags, and looping
    * `S_MusicExists` - Checks wadfiles for existing music name
* I ripped out SDL Mixer code in `sdl_sound.c` because it's never invoked.
    * The file is only used when you build with `NOMIXER=1`. The music code is hidden under `#ifdef HAVE_MIXER`, and so that build never plays music.
* Menu tweaks
    * When toggling music, play the level music instead of the clear jingle
    * When toggling digital/MIDI, play music automatically if a digital or MIDI track exists

# Implementation

The only things that remain separate between digital/MIDI is toggling and volume. The Win32 MIDI volume hack is still in effect.

I conformed the other targets (DOS, DirectX/FMOD, Dummy, etc.) as best as I could. DirectX and `NOMIXER=1` both build. Some targets have been unchanged because they're removed from 2.2 (like XBOX.)