### PR TITLE
Makefile: Split zlib and libpng

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -66,6 +66,7 @@
 #     Compile without 3D sound support, add 'NOHS=1'
 #     Compile with GDBstubs, add 'RDB=1'
 #     Compile without PNG, add 'NOPNG=1'
+#     Compile without zlib, add 'NOZLIB=1'
 #
 # Addon for SDL:
 #     To Cross-Compile, add 'SDL_CONFIG=/usr/*/bin/sdl-config'
@@ -119,6 +120,7 @@ include Makefile.cfg
 
 ifdef DUMMY
 NOPNG=1
+NOZLIB=1
 NONET=1
 NOHW=1
 NOHS=1
@@ -199,6 +201,7 @@ endif
 
 ifdef NDS
 NOPNG=1
+NOZLIB=1
 NONET=1
 #NOHW=1
 NOHS=1
@@ -325,13 +328,6 @@ LIBS+=$(PNG_LDFLAGS)
 CFLAGS+=$(PNG_CFLAGS)
 endif
 
-ZLIB_PKGCONFIG?=zlib
-ZLIB_CFLAGS?=$(shell $(PKG_CONFIG) $(ZLIB_PKGCONFIG) --cflags)
-ZLIB_LDFLAGS?=$(shell $(PKG_CONFIG) $(ZLIB_PKGCONFIG) --libs)
-
-LIBS+=$(ZLIB_LDFLAGS)
-CFLAGS+=$(ZLIB_CFLAGS)
-
 ifdef HAVE_LIBGME
 OPTS+=-DHAVE_LIBGME
 
@@ -341,6 +337,18 @@ LIBGME_LDFLAGS?=$(shell $(PKG_CONFIG) $(LIBGME_PKGCONFIG) --libs)
 
 LIBS+=$(LIBGME_LDFLAGS)
 CFLAGS+=$(LIBGME_CFLAGS)
+endif
+
+ifndef NOZLIB
+OPTS+=-DHAVE_ZLIB
+ZLIB_PKGCONFIG?=zlib
+ZLIB_CFLAGS?=$(shell $(PKG_CONFIG) $(ZLIB_PKGCONFIG) --cflags)
+ZLIB_LDFLAGS?=$(shell $(PKG_CONFIG) $(ZLIB_PKGCONFIG) --libs)
+
+LIBS+=$(ZLIB_LDFLAGS)
+CFLAGS+=$(ZLIB_CFLAGS)
+else
+NOPNG=1
 endif
 
 ifdef STATIC

--- a/src/sdl/mixer_sound.c
+++ b/src/sdl/mixer_sound.c
@@ -38,9 +38,6 @@
 #include "gme/gme.h"
 #define GME_TREBLE 5.0
 #define GME_BASS 1.0
-#ifdef HAVE_PNG /// TODO: compile with zlib support without libpng
-
-#define HAVE_ZLIB
 
 #ifndef _MSC_VER
 #ifndef _LARGEFILE64_SOURCE
@@ -56,8 +53,11 @@
 #define _FILE_OFFSET_BITS 0
 #endif
 
-#include "zlib.h"
 #endif
+#endif
+
+#ifdef HAVE_ZLIB
+#include "zlib.h"
 #endif
 
 UINT8 sound_started = false;
@@ -361,7 +361,7 @@ void *I_GetSfx(sfxinfo_t *sfx)
 		}
 		Z_Free(inflatedData); // GME didn't open jack, but don't let that stop us from freeing this up
 #else
-		//CONS_Alert(CONS_ERROR,"Cannot decompress VGZ; no zlib support\n");
+		return NULL; // No zlib support
 #endif
 	}
 	// Try to read it as a GME sound
@@ -621,7 +621,8 @@ boolean I_StartDigSong(const char *musicname, boolean looping)
 		}
 		Z_Free(inflatedData); // GME didn't open jack, but don't let that stop us from freeing this up
 #else
-		//CONS_Alert(CONS_ERROR,"Cannot decompress VGZ; no zlib support\n");
+		CONS_Alert(CONS_ERROR,"Cannot decompress VGZ; no zlib support\n");
+		return true;
 #endif
 	}
 	else if (!gme_open_data(data, len, &gme, 44100))
@@ -841,5 +842,3 @@ void I_UnRegisterSong(INT32 handle)
 	Mix_FreeMusic(music);
 	music = NULL;
 }
-
-#endif

--- a/src/sdl/mixer_sound.c
+++ b/src/sdl/mixer_sound.c
@@ -52,10 +52,10 @@
 #ifndef _FILE_OFFSET_BITS
 #define _FILE_OFFSET_BITS 0
 #endif
-#endif
 
 #ifdef HAVE_ZLIB
 #include "zlib.h"
+#endif
 #endif
 
 UINT8 sound_started = false;

--- a/src/sdl/mixer_sound.c
+++ b/src/sdl/mixer_sound.c
@@ -52,8 +52,6 @@
 #ifndef _FILE_OFFSET_BITS
 #define _FILE_OFFSET_BITS 0
 #endif
-
-#endif
 #endif
 
 #ifdef HAVE_ZLIB
@@ -842,3 +840,5 @@ void I_UnRegisterSong(INT32 handle)
 	Mix_FreeMusic(music);
 	music = NULL;
 }
+
+#endif

--- a/src/sdl/mixer_sound.c
+++ b/src/sdl/mixer_sound.c
@@ -39,6 +39,7 @@
 #define GME_TREBLE 5.0
 #define GME_BASS 1.0
 
+#ifdef HAVE_ZLIB
 #ifndef _MSC_VER
 #ifndef _LARGEFILE64_SOURCE
 #define _LARGEFILE64_SOURCE
@@ -53,10 +54,9 @@
 #define _FILE_OFFSET_BITS 0
 #endif
 
-#ifdef HAVE_ZLIB
 #include "zlib.h"
-#endif
-#endif
+#endif // HAVE_ZLIB
+#endif // HAVE_LIBGME
 
 UINT8 sound_started = false;
 

--- a/src/win32/win_snd.c
+++ b/src/win32/win_snd.c
@@ -17,9 +17,6 @@
 #include "gme/gme.h"
 #define GME_TREBLE 5.0
 #define GME_BASS 1.0
-#ifdef HAVE_PNG /// TODO: compile with zlib support without libpng
-
-#define HAVE_ZLIB
 
 #ifndef _MSC_VER
 #ifndef _WII

--- a/src/win32/win_snd.c
+++ b/src/win32/win_snd.c
@@ -18,11 +18,10 @@
 #define GME_TREBLE 5.0
 #define GME_BASS 1.0
 
+#ifdef HAVE_ZLIB
 #ifndef _MSC_VER
-#ifndef _WII
 #ifndef _LARGEFILE64_SOURCE
 #define _LARGEFILE64_SOURCE
-#endif
 #endif
 #endif
 
@@ -34,10 +33,9 @@
 #define _FILE_OFFSET_BITS 0
 #endif
 
-#ifdef HAVE_ZLIB
 #include "zlib.h"
-#endif
-#endif
+#endif // HAVE_ZLIB
+#endif // HAVE_LIBGME
 
 static FMOD_SYSTEM *fsys;
 static FMOD_SOUND *music_stream;

--- a/src/win32/win_snd.c
+++ b/src/win32/win_snd.c
@@ -34,6 +34,7 @@
 #define _FILE_OFFSET_BITS 0
 #endif
 
+#ifdef HAVE_ZLIB
 #include "zlib.h"
 #endif
 #endif


### PR DESCRIPTION
Split zlib stuff from libpng, removing the hard dependency on libpng to decompress VGZ lumps, also uncommented lines that was commented out in sdl/mixer_sound.c, for whatever reason. If someone compiles without zlib, then PNG support will be explicitly disabled also.