### PR TITLE
Fixer mixer: Mixer Memory Leaks

### DIFF
--- a/src/sdl/mixer_sound.c
+++ b/src/sdl/mixer_sound.c
@@ -178,7 +178,7 @@ static Mix_Chunk *ds2chunk(void *stream)
 			return NULL; // would and/or did wrap, can't store.
 		break;
 	}
-	sound = Z_Malloc(newsamples<<2, PU_SOUND, 0); // samples * frequency shift * bytes per sample * channels
+	sound = Z_Malloc(newsamples<<2, PU_SOUND, NULL); // samples * frequency shift * bytes per sample * channels
 
 	s = (SINT8 *)stream;
 	d = (INT16 *)sound;

--- a/src/sdl/mixer_sound.c
+++ b/src/sdl/mixer_sound.c
@@ -387,7 +387,15 @@ void *I_GetSfx(sfxinfo_t *sfx)
 #endif
 
 	// Try to load it as a WAVE or OGG using Mixer.
-	return Mix_LoadWAV_RW(SDL_RWFromMem(lump, sfx->length), 1);
+	SDL_RWops *rw = SDL_RWFromMem(lump, sfx->length);
+	if (rw != NULL)
+	{
+		Mix_Chunk *chunk = Mix_LoadWAV_RW(rw, 1);
+		SDL_RWclose(rw);
+		return chunk;
+	}
+
+	return NULL; // haven't been able to get anything
 }
 
 void I_FreeSfx(sfxinfo_t *sfx)
@@ -635,7 +643,12 @@ boolean I_StartDigSong(const char *musicname, boolean looping)
 	}
 #endif
 
-	music = Mix_LoadMUS_RW(SDL_RWFromMem(data, len), SDL_FALSE);
+	SDL_RWops *rw = SDL_RWFromMem(data, len);
+	if (rw != NULL)
+	{
+		music = Mix_LoadMUS_RW(rw, SDL_FALSE);
+		SDL_RWclose(rw);
+	}
 	if (!music)
 	{
 		CONS_Alert(CONS_ERROR, "Mix_LoadMUS_RW: %s\n", Mix_GetError());
@@ -798,7 +811,12 @@ void I_SetMIDIMusicVolume(UINT8 volume)
 
 INT32 I_RegisterSong(void *data, size_t len)
 {
-	music = Mix_LoadMUS_RW(SDL_RWFromMem(data, len), SDL_FALSE);
+	SDL_RWops *rw = SDL_RWFromMem(data, len);
+	if (rw != NULL)
+	{
+		music = Mix_LoadMUS_RW(rw, SDL_FALSE);
+		SDL_RWclose(rw);
+	}
 	if (!music)
 	{
 		CONS_Alert(CONS_ERROR, "Mix_LoadMUS_RW: %s\n", Mix_GetError());


### PR DESCRIPTION
Fix the memory leaks from the SDL2 Mixer interface.
Mix_QuickLoad_RAW loaded Mix_Chunk's don't free the data used in Mix_FreeChunk since we allocated it. So Free it manually in I_FreeSfx. This means the allocation in ds2chunk can go back to being Z_Malloc.
The SDL_RWops from SDL_RWFromMem need to be closed after being used.