### PR TITLE
Tiny fix so that joystick2 being closed can let the JoystickSubSystem close before game close.

### DIFF
--- a/src/sdl/i_system.c
+++ b/src/sdl/i_system.c
@@ -1154,6 +1154,7 @@ static void I_ShutdownJoystick2(void)
 		D_PostEvent(&event);
 	}
 
+	joystick2_started = 0;
 	JoyReset(&JoyInfo2);
 	if (!joystick_started && !joystick2_started && SDL_WasInit(SDL_INIT_JOYSTICK) == SDL_INIT_JOYSTICK)
 	{


### PR DESCRIPTION
On the topic of tiny fixes.
No memory leak here, just a very tiny thing I noticed.
The memory issue I did see I believe is either the fault of SDL2 or the library it's using on my system.