### PR TITLE
Endgame code refactor

### DIFF
--- a/src/f_finale.c
+++ b/src/f_finale.c
@@ -1733,7 +1733,7 @@ static void F_AdvanceToNextScene(void)
 
 void F_EndCutScene(void)
 {
-	cutsceneover = true; // do this first, just in case Y_EndGame or something wants to turn it back false later
+	cutsceneover = true; // do this first, just in case G_EndGame or something wants to turn it back false later
 	if (runningprecutscene)
 	{
 		if (server)
@@ -1748,7 +1748,7 @@ void F_EndCutScene(void)
 		else if (nextmap < 1100-1)
 			G_NextLevel();
 		else
-			Y_EndGame();
+			G_EndGame();
 	}
 }
 

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -2615,7 +2615,7 @@ void G_ExitLevel(void)
 			CONS_Printf(M_GetText("The round has ended.\n"));
 
 		// Remove CEcho text on round end.
-		HU_DoCEcho("");
+		HU_ClearCEcho();
 	}
 }
 

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -2999,10 +2999,10 @@ static void G_DoContinued(void)
 
 //
 // G_EndGame (formerly Y_EndGame)
-// Franky this function fits better in g_game.c than it does in y_inter.c
+// Frankly this function fits better in g_game.c than it does in y_inter.c
 //
 // ...Gee, (why) end the game?
-// Because Y_FollowIntermission and F_EndCutscene would
+// Because G_AfterIntermission and F_EndCutscene would
 // both do this exact same thing *in different ways* otherwise,
 // which made it so that you could only unlock Ultimate mode
 // if you had a cutscene after the final level and crap like that.

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -2911,7 +2911,7 @@ void G_AfterIntermission(void)
 		if (nextmap < 1100-1)
 			G_NextLevel();
 		else
-			Y_EndGame();
+			G_EndGame();
 	}
 }
 
@@ -2995,6 +2995,38 @@ static void G_DoContinued(void)
 	D_MapChange(gamemap, gametype, ultimatemode, false, 0, false, false);
 
 	gameaction = ga_nothing;
+}
+
+//
+// G_EndGame (formerly Y_EndGame)
+// Franky this function fits better in g_game.c than it does in y_inter.c
+//
+// ...Gee, (why) end the game?
+// Because Y_FollowIntermission and F_EndCutscene would
+// both do this exact same thing *in different ways* otherwise,
+// which made it so that you could only unlock Ultimate mode
+// if you had a cutscene after the final level and crap like that.
+// This function simplifies it so only one place has to be updated
+// when something new is added.
+void G_EndGame(void)
+{
+	// Only do evaluation and credits in coop games.
+	if (gametype == GT_COOP)
+	{
+		if (nextmap == 1102-1) // end game with credits
+		{
+			F_StartCredits();
+			return;
+		}
+		if (nextmap == 1101-1) // end game with evaluation
+		{
+			F_StartGameEvaluation();
+			return;
+		}
+	}
+
+	// 1100 or competitive multiplayer, so go back to title screen.
+	D_StartTitle();
 }
 
 //

--- a/src/g_game.h
+++ b/src/g_game.h
@@ -171,6 +171,7 @@ void G_NextLevel(void);
 void G_Continue(void);
 void G_UseContinue(void);
 void G_AfterIntermission(void);
+void G_EndGame(void); // moved from y_inter.c/h and renamed
 
 void G_Ticker(boolean run);
 boolean G_Responder(event_t *ev);

--- a/src/y_inter.c
+++ b/src/y_inter.c
@@ -1805,21 +1805,10 @@ static void Y_FollowIntermission(void)
 		return;
 	}
 
-	if (nextmap < 1100-1)
-	{
-		// normal level
-		G_AfterIntermission();
-		return;
-	}
-
-	// Start a custom cutscene if there is one.
-	if (mapheaderinfo[gamemap-1]->cutscenenum && !modeattacking)
-	{
-		F_StartCustomCutscene(mapheaderinfo[gamemap-1]->cutscenenum-1, false, false);
-		return;
-	}
-
-	G_EndGame();
+	// This handles whether to play a post-level cutscene, end the game,
+	// or simply go to the next level.
+	// No need to duplicate the code here!
+	G_AfterIntermission();
 }
 
 #define UNLOAD(x) Z_ChangeTag(x, PU_CACHE); x = NULL

--- a/src/y_inter.c
+++ b/src/y_inter.c
@@ -1795,37 +1795,6 @@ void Y_EndIntermission(void)
 }
 
 //
-// Y_EndGame
-//
-// Why end the game?
-// Because Y_FollowIntermission and F_EndCutscene would
-// both do this exact same thing *in different ways* otherwise,
-// which made it so that you could only unlock Ultimate mode
-// if you had a cutscene after the final level and crap like that.
-// This function simplifies it so only one place has to be updated
-// when something new is added.
-void Y_EndGame(void)
-{
-	// Only do evaluation and credits in coop games.
-	if (gametype == GT_COOP)
-	{
-		if (nextmap == 1102-1) // end game with credits
-		{
-			F_StartCredits();
-			return;
-		}
-		if (nextmap == 1101-1) // end game with evaluation
-		{
-			F_StartGameEvaluation();
-			return;
-		}
-	}
-
-	// 1100 or competitive multiplayer, so go back to title screen.
-	D_StartTitle();
-}
-
-//
 // Y_FollowIntermission
 //
 static void Y_FollowIntermission(void)
@@ -1850,7 +1819,7 @@ static void Y_FollowIntermission(void)
 		return;
 	}
 
-	Y_EndGame();
+	G_EndGame();
 }
 
 #define UNLOAD(x) Z_ChangeTag(x, PU_CACHE); x = NULL

--- a/src/y_inter.h
+++ b/src/y_inter.h
@@ -15,7 +15,6 @@ void Y_IntermissionDrawer(void);
 void Y_Ticker(void);
 void Y_StartIntermission(void);
 void Y_EndIntermission(void);
-void Y_EndGame(void);
 
 typedef enum
 {


### PR DESCRIPTION
This is mostly just some code cleanup and moving about:
* `Y_EndGame` was moved from from y_inter.c/h to g_game.c/h, and renamed to `G_EndGame`. Frankly the old place that function lived didn't make sense, since it has nothing to do with tally screens directly.
* Most of `Y_FollowIntermission`'s code was removed, because `G_AfterIntermission` does it all already.
* And lastly, `G_ExitLevel` uses `HU_ClearCEcho()` instead of `HU_CEcho("")` to clear CEchos from the screen.

The only visible changes in-game from the above should be just that log.txt stops adding empty new lines when you complete a level, and CEchos will always be cleared after tally screens when a level goes to credits/evaluation next.

(Backport from 2.2)