### PR TITLE
Objectplace: Fix NiGHTS bumper angle being reset when WRITETHINGS

### DIFF
--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -9194,9 +9194,6 @@ ML_NOCLIMB : Direction not controllable
 		// the bumper in 30 degree increments.
 		mobj->threshold = (mthing->options & 15) % 12; // It loops over, etc
 		P_SetMobjState(mobj, mobj->info->spawnstate+mobj->threshold);
-
-		// you can shut up now, OBJECTFLIP.  And all of the other options, for that matter.
-		mthing->options &= ~0xF;
 		break;
 	case MT_EGGCAPSULE:
 		if (mthing->angle <= 0)

--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -9381,6 +9381,14 @@ ML_NOCLIMB : Direction not controllable
 		}
 	}
 
+	// ignore MTF_ flags and return early
+	if (i == MT_NIGHTSBUMPER)
+	{
+		mobj->angle = FixedAngle(mthing->angle*FRACUNIT);
+		mthing->mobj = mobj;
+		return;
+	}
+
 	mobj->angle = FixedAngle(mthing->angle*FRACUNIT);
 
 	if ((mthing->options & MTF_AMBUSH)


### PR DESCRIPTION
When WRITETHINGS, all NiGHTS Bumper vertical angles were reset because their flag values were being fudged after mobj spawn. Don't do this!

Backported from 2.2.