### PR TITLE
NiGHTS fix lap detection on inverted axis

### DIFF
--- a/src/p_map.c
+++ b/src/p_map.c
@@ -777,8 +777,8 @@ static boolean PIT_CheckThing(mobj_t *thing)
 		// not (your direction) xor (stored direction)
 		// In other words, you can't u-turn and respawn rings near the drone.
 		if (pl->bonustime && (pl->pflags & PF_NIGHTSMODE) && (INT32)leveltime > droneobj->extravalue2 && (
-		   !(pl->flyangle >= 90 &&   pl->flyangle <= 270)
-		^ (droneobj->extravalue1 >= 90 && droneobj->extravalue1 <= 270)
+		   !(pl->flyangle > 90 &&   pl->flyangle < 270)
+		^ (droneobj->extravalue1 > 90 && droneobj->extravalue1 < 270)
 		))
 		{
 			// Reload all the fancy ring stuff!

--- a/src/p_map.c
+++ b/src/p_map.c
@@ -777,14 +777,14 @@ static boolean PIT_CheckThing(mobj_t *thing)
 		// not (your direction) xor (stored direction)
 		// In other words, you can't u-turn and respawn rings near the drone.
 		if (pl->bonustime && (pl->pflags & PF_NIGHTSMODE) && (INT32)leveltime > droneobj->extravalue2 && (
-		   !(pl->anotherflyangle >= 90 &&   pl->anotherflyangle <= 270)
+		   !(pl->flyangle >= 90 &&   pl->flyangle <= 270)
 		^ (droneobj->extravalue1 >= 90 && droneobj->extravalue1 <= 270)
 		))
 		{
 			// Reload all the fancy ring stuff!
 			P_ReloadRings();
 		}
-		droneobj->extravalue1 = pl->anotherflyangle;
+		droneobj->extravalue1 = pl->flyangle;
 		droneobj->extravalue2 = (INT32)leveltime + TICRATE;
 	}
 


### PR DESCRIPTION
Backported from 2.2.

Prior, if drone is on inverted axis, player could break lap detection (which dictates hoop/ring respawn during bonus time) just by U-turning. `player->anotherflyangle` breaks in this case. 

[Example GIF](https://i.imgur.com/eORSzVR.gif)

Fixed by using `player->flyangle` instead. No ill effects, works as expected in both regular and inverted axis types.

See [here](https://mb.srb2.org/showthread.php?t=43304) for discussion.

## Note about `> <` vs `>= <=` comparison

Due to using `flyangle`, this also changes the angle comparison slightly (`> 90 && < 270` instead of `>= 90 && <= 270`) to account for the edge case where flying directly up (`flyangle 90`) or directly down (`flyangle 270`) is registered as a BACKWARDS loop, not a FORWARDS loop. So if you `JUMPTOAXIS` out of drone while flyangle 90 or 270, you could only trigger a loop by flying the track BACKWARDS. This edge case, though impossible without `JUMPTOAXIS`, should default to a FORWARDS loop. 

`anotherflyangle` worked differently so this bug did not exist with the >= comparison.