### PR TITLE
Winsock error handling fixes

### DIFF
--- a/src/i_tcp.c
+++ b/src/i_tcp.c
@@ -266,7 +266,7 @@ static void wattcp_outch(char s)
 // stupid microsoft makes things complicated
 static inline char *get_WSAErrorStr(int e)
 {
-	char buf[256]; // allow up to 255 bytes
+	static char buf[256]; // allow up to 255 bytes
 
 	buf[0] = '\0';
 

--- a/src/i_tcp.c
+++ b/src/i_tcp.c
@@ -781,9 +781,13 @@ static void SOCK_Send(void)
 			&clientaddress[doomcom->remotenode].any, d);
 	}
 
-	if (c == ERRSOCKET && errno != ECONNREFUSED && errno != EWOULDBLOCK)
-		I_Error("SOCK_Send, error sending to node %d (%s) #%u: %s", doomcom->remotenode,
-			SOCK_GetNodeAddress(doomcom->remotenode), errno, strerror(errno));
+	if (c == ERRSOCKET)
+	{
+		int e = errno; // save error code so it can't be modified later
+		if (e != ECONNREFUSED && e != EWOULDBLOCK)
+			I_Error("SOCK_Send, error sending to node %d (%s) #%u: %s", doomcom->remotenode,
+				SOCK_GetNodeAddress(doomcom->remotenode), e, strerror(e));
+	}
 }
 #endif
 

--- a/src/i_tcp.c
+++ b/src/i_tcp.c
@@ -262,6 +262,28 @@ static void wattcp_outch(char s)
 }
 #endif
 
+#ifdef USE_WINSOCK
+// stupid microsoft makes things complicated
+static inline char *get_WSAErrorStr(int e)
+{
+	char *buf = NULL;
+
+	FormatMessageA(
+		FORMAT_MESSAGE_ALLOCATE_BUFFER |
+		FORMAT_MESSAGE_FROM_SYSTEM |
+		FORMAT_MESSAGE_IGNORE_INSERTS,
+		NULL,
+		(DWORD)e,
+		MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+		(LPTSTR)&buf,
+		0, NULL);
+
+	return buf;
+}
+#undef strerror
+#define strerror get_WSAErrorStr
+#endif
+
 #ifdef USE_WINSOCK2
 #define inet_ntop inet_ntopA
 #define HAVE_NTOP

--- a/src/i_tcp.c
+++ b/src/i_tcp.c
@@ -266,17 +266,22 @@ static void wattcp_outch(char s)
 // stupid microsoft makes things complicated
 static inline char *get_WSAErrorStr(int e)
 {
-	char *buf = NULL;
+	char buf[256]; // allow up to 255 bytes
+
+	buf[0] = '\0';
 
 	FormatMessageA(
-		FORMAT_MESSAGE_ALLOCATE_BUFFER |
 		FORMAT_MESSAGE_FROM_SYSTEM |
 		FORMAT_MESSAGE_IGNORE_INSERTS,
 		NULL,
 		(DWORD)e,
 		MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-		(LPTSTR)&buf,
-		0, NULL);
+		(LPTSTR)buf,
+		sizeof (buf),
+		NULL);
+
+	if (!buf[0]) // provide a fallback error message if no message is available for some reason
+		sprintf(buf, "Unknown error");
 
 	return buf;
 }


### PR DESCRIPTION
This branch (hopefully) fixes any `SOCK_Send` errors producing the useless `#0: No error` nonsense that people have been reporting for a while now for Windows versions of SRB2. While it doesn't fix the cause of the errors, it should correctly report the error codes for them now. And if I did things right, it should actually print an actual message for the error as well now.