### PR TITLE
Lua: hud.enabled and v.getLocalTransFlag()

### DIFF
--- a/src/lua_hudlib.c
+++ b/src/lua_hudlib.c
@@ -560,6 +560,15 @@ static int libd_renderer(lua_State *L)
 	return 1;
 }
 
+// 30/10/18 Lat': Get cv_translucenthud's value for HUD rendering as a normal V_xxTRANS int
+// Could as well be thrown in global vars for ease of access but I guess it makes sense for it to be a HUD fn
+static int libd_getlocaltransflag(lua_State *L)
+{
+	HUDONLY
+	lua_pushinteger(L, (10-cv_translucenthud.value)*V_10TRANS);	// A bit weird that it's called "translucenthud" yet 10 is fully opaque :V
+	return 1;
+}
+
 static luaL_Reg lib_draw[] = {
 	{"patchExists", libd_patchExists},
 	{"cachePatch", libd_cachePatch},
@@ -576,6 +585,7 @@ static luaL_Reg lib_draw[] = {
 	{"dupx", libd_dupx},
 	{"dupy", libd_dupy},
 	{"renderer", libd_renderer},
+	{"localTransFlag", libd_getlocaltransflag},
 	{NULL, NULL}
 };
 
@@ -598,6 +608,20 @@ static int lib_huddisable(lua_State *L)
 	hud_enabled[option/8] &= ~(1<<(option%8));
 	return 0;
 }
+
+// 30/10/18: Lat': How come this wasn't here before?
+static int lib_hudenabled(lua_State *L)
+{
+	enum hud option = luaL_checkoption(L, 1, NULL, hud_disable_options);
+	lua_settop(L, 2);
+	if (!gL || hud_enabled[option/8] & (1<<(option%8)))
+		lua_pushboolean(L, true);
+	else
+		lua_pushboolean(L, false);
+
+	return 1;
+}
+
 
 // add a HUD element for rendering
 static int lib_hudadd(lua_State *L)
@@ -623,6 +647,7 @@ static int lib_hudadd(lua_State *L)
 static luaL_Reg lib_hud[] = {
 	{"enable", lib_hudenable},
 	{"disable", lib_huddisable},
+	{"enabled", lib_hudenabled},
 	{"add", lib_hudadd},
 	{NULL, NULL}
 };

--- a/src/lua_hudlib.c
+++ b/src/lua_hudlib.c
@@ -614,7 +614,7 @@ static int lib_hudenabled(lua_State *L)
 {
 	enum hud option = luaL_checkoption(L, 1, NULL, hud_disable_options);
 	lua_settop(L, 2);
-	if (!gL || hud_enabled[option/8] & (1<<(option%8)))
+	if (hud_enabled[option/8] & (1<<(option%8)))
 		lua_pushboolean(L, true);
 	else
 		lua_pushboolean(L, false);

--- a/src/lua_hudlib.c
+++ b/src/lua_hudlib.c
@@ -613,7 +613,6 @@ static int lib_huddisable(lua_State *L)
 static int lib_hudenabled(lua_State *L)
 {
 	enum hud option = luaL_checkoption(L, 1, NULL, hud_disable_options);
-	lua_settop(L, 2);
 	if (hud_enabled[option/8] & (1<<(option%8)))
 		lua_pushboolean(L, true);
 	else


### PR DESCRIPTION
Adds simple Lua functions that can probably go a long way... more or less:
*  hud.enabled(huditem) will return true or false depending on if huditem is enabled or disabled, which will DEFINITELY help mods using huds not look out of place when another mod decides to disable huds for misc purposes.
*  v.getLocalTransFlag() is a way more situational, it returns V_HUDTRANS as a regular V_xxTRANS flag, which means that people can work from that transparency to get consistent results with the player's settings.