### PR TITLE
File loading hotfix

### DIFF
--- a/src/w_wad.c
+++ b/src/w_wad.c
@@ -381,6 +381,8 @@ UINT16 W_LoadWadFile(const char *filename)
 		if (fread(&header, 1, sizeof header, handle) < sizeof header)
 		{
 			CONS_Alert(CONS_ERROR, M_GetText("Can't read wad header from %s because %s\n"), filename, strerror(ferror(handle)));
+			if (handle)
+				fclose(handle);
 			return INT16_MAX;
 		}
 
@@ -391,6 +393,8 @@ UINT16 W_LoadWadFile(const char *filename)
 			&& memcmp(header.identification, "SDLL", 4) != 0)
 		{
 			CONS_Alert(CONS_ERROR, M_GetText("%s does not have a valid WAD header\n"), filename);
+			if (handle)
+				fclose(handle);
 			return INT16_MAX;
 		}
 
@@ -405,6 +409,8 @@ UINT16 W_LoadWadFile(const char *filename)
 		{
 			CONS_Alert(CONS_ERROR, M_GetText("Wadfile directory in %s is corrupted (%s)\n"), filename, strerror(ferror(handle)));
 			free(fileinfov);
+			if (handle)
+				fclose(handle);
 			return INT16_MAX;
 		}
 
@@ -462,6 +468,8 @@ UINT16 W_LoadWadFile(const char *filename)
 		if (!memcmp(wadfiles[i]->md5sum, md5sum, 16))
 		{
 			CONS_Alert(CONS_ERROR, M_GetText("%s is already loaded\n"), filename);
+			if (handle)
+				fclose(handle);
 			return INT16_MAX;
 		}
 	}


### PR DESCRIPTION
Fixes [SRB2MB: Executing a TXT a lot makes the game no longer saves your config/data](https://mb.srb2.org/showthread.php?t=43687).

Turns out that when you attempt to add a file that's already loaded, the game forgets to close its handle. This means that if you add the file enough times you actually hit the limit for how many files you can have open eventually. The MB's thread way is just one way of getting this quickly it turns out; another one found by Steel is just having many lines of adding the same file redundantly in the text file, where you only need to run it once before you get the same bug.