### PR TITLE
Fix for object z positions on floating, bobbing FOFs

### DIFF
--- a/src/p_floor.c
+++ b/src/p_floor.c
@@ -811,6 +811,8 @@ void T_BounceCheese(levelspecthink_t *bouncer)
 		{
 			bouncer->sector->ceilingheight = actionsector->ceilingheight;
 			bouncer->sector->floorheight = bouncer->sector->ceilingheight - (halfheight*2);
+			T_MovePlane(bouncer->sector, 0, bouncer->sector->ceilingheight, 0, 1, -1); // update things on ceiling
+			T_MovePlane(bouncer->sector, 0, bouncer->sector->floorheight, 0, 0, -1); // update things on floor
 			P_RecalcPrecipInSector(actionsector);
 			bouncer->sector->ceilingdata = NULL;
 			bouncer->sector->floordata = NULL;
@@ -825,6 +827,8 @@ void T_BounceCheese(levelspecthink_t *bouncer)
 		{
 			bouncer->sector->ceilingheight = floorheight + (halfheight << 1);
 			bouncer->sector->floorheight = floorheight;
+			T_MovePlane(bouncer->sector, 0, bouncer->sector->ceilingheight, 0, 1, -1); // update things on ceiling
+			T_MovePlane(bouncer->sector, 0, bouncer->sector->floorheight, 0, 0, -1); // update things on floor
 			P_RecalcPrecipInSector(actionsector);
 			bouncer->sector->ceilingdata = NULL;
 			bouncer->sector->floordata = NULL;
@@ -841,9 +845,9 @@ void T_BounceCheese(levelspecthink_t *bouncer)
 		}
 
 		T_MovePlane(bouncer->sector, bouncer->speed/2, bouncer->sector->ceilingheight -
-			70*FRACUNIT, 0, 1, -1); // move floor
+			70*FRACUNIT, 0, 1, -1); // move ceiling
 		T_MovePlane(bouncer->sector, bouncer->speed/2, bouncer->sector->floorheight - 70*FRACUNIT,
-			0, 0, -1); // move ceiling
+			0, 0, -1); // move floor
 
 		bouncer->sector->floorspeed = -bouncer->speed/2;
 		bouncer->sector->ceilspeed = 42;
@@ -893,6 +897,8 @@ void T_BounceCheese(levelspecthink_t *bouncer)
 		{
 			bouncer->sector->floorheight = bouncer->floorwasheight;
 			bouncer->sector->ceilingheight = bouncer->ceilingwasheight;
+			T_MovePlane(bouncer->sector, 0, bouncer->sector->ceilingheight, 0, 1, -1); // update things on ceiling
+			T_MovePlane(bouncer->sector, 0, bouncer->sector->floorheight, 0, 0, -1); // update things on floor
 			bouncer->sector->ceilingdata = NULL;
 			bouncer->sector->floordata = NULL;
 			bouncer->sector->floorspeed = 0;


### PR DESCRIPTION
See [SRB2MB: The Deathly Monitors II: The Ghostly, Jumpy, Occasionally Sticky Monitors](https://mb.srb2.org/showthread.php?t=39784) for some context.

I found out three years ago that the cause of the first issue in the thread was a combination of several things: a fix I made once to fix solid objects suddenly warping on top of another, and the little-known fact that the monitor actually is just *slightly* above the FOF itself at the end of the bob. Apparently at some point during those three years physics of solid objects were changed again, fixing the intangibility part... but not the latter technicality.

This branch fixes objects on floating, bobbing FOFs so that they are *definitely* on top of the FOF at the very end of a bob. This would have fixed the thread's first issue even if it wasn't fixed by other means already.

If you guys want pretty animations to help understand what's going on, here you go:

Before the fix:

![srb20147](https://git.magicalgirl.moe/STJr/SRB2/uploads/88eae1475e9f79aa6178331dce781b50/srb20147.gif)

After the fix:

![srb20148](https://git.magicalgirl.moe/STJr/SRB2/uploads/63ab937cda220818ae32f80aeb5b0530/srb20148.gif)