### PR TITLE
Objectplace skybox fix.

### DIFF
--- a/src/info.c
+++ b/src/info.c
@@ -12733,7 +12733,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] =
 		10,             // mass
 		0,              // damage
 		sfx_None,       // activesound
-		MF_NOTHINK|MF_NOBLOCKMAP|MF_NOGRAVITY, // flags
+		MF_SCENERY|MF_NOBLOCKMAP|MF_NOGRAVITY, // flags
 		S_NULL          // raisestate
 	},
 


### PR DESCRIPTION
This branch fixes the skybox disappearing after using objectplace command. The fix is really simple, but it works!