### PR TITLE
Remove unnecessary SDLCALL from IMG_xpm.c declarations

### DIFF
--- a/src/sdl/IMG_xpm.c
+++ b/src/sdl/IMG_xpm.c
@@ -44,14 +44,11 @@
 
 #if 0
 #include "SDL_image.h"
-
-extern SDLCALL int SDLCALL IMG_isXPM(SDL_RWops *src);
-extern SDLCALL SDL_Surface *IMG_LoadXPM_RW(SDL_RWops *src);
-extern SDLCALL SDL_Surface * SDLCALL IMG_ReadXPMFromArray(const char **xpm);
 #else
-extern int IMG_isXPM(SDL_RWops *src);
-extern SDL_Surface *IMG_LoadXPM_RW(SDL_RWops *src);
-extern SDL_Surface *IMG_ReadXPMFromArray(const char **xpm);
+// SDLCALL terms removed from original SDL_image declarations
+int IMG_isXPM(SDL_RWops *src);
+SDL_Surface *IMG_LoadXPM_RW(SDL_RWops *src);
+SDL_Surface *IMG_ReadXPMFromArray(const char **xpm);
 #define IMG_SetError    SDL_SetError
 #define IMG_GetError    SDL_GetError
 #endif

--- a/src/sdl/IMG_xpm.c
+++ b/src/sdl/IMG_xpm.c
@@ -44,10 +44,14 @@
 
 #if 0
 #include "SDL_image.h"
-#else
+
 extern SDLCALL int SDLCALL IMG_isXPM(SDL_RWops *src);
 extern SDLCALL SDL_Surface *IMG_LoadXPM_RW(SDL_RWops *src);
 extern SDLCALL SDL_Surface * SDLCALL IMG_ReadXPMFromArray(const char **xpm);
+#else
+extern int IMG_isXPM(SDL_RWops *src);
+extern SDL_Surface *IMG_LoadXPM_RW(SDL_RWops *src);
+extern SDL_Surface *IMG_ReadXPMFromArray(const char **xpm);
 #define IMG_SetError    SDL_SetError
 #define IMG_GetError    SDL_GetError
 #endif


### PR DESCRIPTION
This made VC fail building.

The XPM declarations:

```c
#if 0
#include "SDL_image.h"
#else
extern SDLCALL int SDLCALL IMG_isXPM(SDL_RWops *src);
extern SDLCALL SDL_Surface *IMG_LoadXPM_RW(SDL_RWops *src);
extern SDLCALL SDL_Surface * SDLCALL IMG_ReadXPMFromArray(const char **xpm);
#define IMG_SetError    SDL_SetError
#define IMG_GetError    SDL_GetError
#endif
```

SDLCALL defines:

```c
/* By default SDL uses the C calling convention */
#ifndef SDLCALL
#if (defined(__WIN32__) || defined(__WINRT__)) && !defined(__GNUC__)
#define SDLCALL __cdecl
#elif defined(__OS2__) || defined(__EMX__)
#define SDLCALL _System
# if defined (__GNUC__) && !defined(_System)
#  define _System /* for old EMX/GCC compat.  */
# endif
#else
#define SDLCALL
#endif
#endif /* SDLCALL */
```

SDLCALL expands to nothing on GCC, but expands to `__cdecl` in VC, which threw that compiler off.

It's not necessary because we're not building these functions into a DLL. The previous version of the file did not use SDLCALL.

```c
static inline SDL_Surface *IMG_ReadXPMFromArray(const char **xpm)
{
        return load_xpm(xpm, NULL);
}
```

With this fix, VC builds correctly.