### PR TITLE
Hide OpenGL loading screen

### DIFF
--- a/src/d_netcmd.c
+++ b/src/d_netcmd.c
@@ -1796,6 +1796,10 @@ static void Got_Mapcmd(UINT8 **cp, INT32 playernum)
 			mapname, resetplayer, lastgametype, gametype, chmappending));
 		CONS_Printf(M_GetText("Speeding off to level...\n"));
 	}
+
+	CON_ToggleOff();
+	CON_ClearHUD();
+
 	if (demoplayback && !timingdemo)
 		precache = false;
 
@@ -1812,7 +1816,6 @@ static void Got_Mapcmd(UINT8 **cp, INT32 playernum)
 	G_InitNew(ultimatemode, mapname, resetplayer, skipprecutscene);
 	if (demoplayback && !timingdemo)
 		precache = true;
-	CON_ToggleOff();
 	if (timingdemo)
 		G_DoneLevelLoad();
 

--- a/src/hardware/hw_bsp.c
+++ b/src/hardware/hw_bsp.c
@@ -633,6 +633,7 @@ static void WalkBSPNode(INT32 bspnum, poly_t *poly, UINT16 *leafnode, fixed_t *b
 			HWR_SubsecPoly(bspnum&(~NF_SUBSECTOR), poly);
 			//Hurdler: implement a loading status
 
+#ifdef HWR_LOADING_SCREEN
 			if (ls_count-- <= 0)
 			{
 				char s[16];
@@ -657,6 +658,7 @@ static void WalkBSPNode(INT32 bspnum, poly_t *poly, UINT16 *leafnode, fixed_t *b
 
 				I_UpdateNoVsync();
 			}
+#endif
 		}
 		M_ClearBox(bbox);
 		poly = extrasubsectors[bspnum&~NF_SUBSECTOR].planepoly;

--- a/src/hardware/hw_glob.h
+++ b/src/hardware/hw_glob.h
@@ -27,6 +27,9 @@
 // the original aspect ratio of Doom graphics isn't square
 #define ORIGINAL_ASPECT (320.0f/200.0f)
 
+// Uncomment this to enable the OpenGL loading screen
+//#define HWR_LOADING_SCREEN
+
 // -----------
 // structures
 // -----------


### PR DESCRIPTION
hw_bsp.c:

```c
// Is this really necessary at this point..?
V_DrawCenteredString(BASEVIDWIDTH/2, 40, V_YELLOWMAP, "OPENGL MODE IS INCOMPLETE AND MAY");
V_DrawCenteredString(BASEVIDWIDTH/2, 50, V_YELLOWMAP, "NOT DISPLAY SOME SURFACES.");
V_DrawCenteredString(BASEVIDWIDTH/2, 70, V_YELLOWMAP, "USE AT SONIC'S RISK.");
```

~~*No, no it's not.*~~

But really. OpenGL hasn't been shown to crash any computers, and we do "kind of" support it. I think the loading screen is due for removal.

This also hides the console slightly earlier in the map change routine, because in OpenGL, switching maps in-console would still display the console for a split second. With the fix, the loading display is now clean and consistent with software.