### PR TITLE
Joystick additions for menu, axis defaults, and vertical look toggle

### DIFF
--- a/src/d_clisrv.c
+++ b/src/d_clisrv.c
@@ -25,6 +25,7 @@
 #include "g_game.h"
 #include "hu_stuff.h"
 #include "keys.h"
+#include "g_input.h" // JOY1
 #include "m_menu.h"
 #include "console.h"
 #include "d_netfil.h"
@@ -1959,7 +1960,7 @@ static boolean CL_ServerConnectionTicker(boolean viams, const char *tmpsave, tic
 
 		I_OsPolling();
 		key = I_GetKey();
-		if (key == KEY_ESCAPE)
+		if (key == KEY_ESCAPE || key == KEY_JOY1+1)
 		{
 			CONS_Printf(M_GetText("Network game synchronization aborted.\n"));
 //				M_StartMessage(M_GetText("Network game synchronization aborted.\n\nPress ESC\n"), NULL, MM_NOTHING);

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -987,9 +987,7 @@ void G_BuildTiccmd(ticcmd_t *cmd, INT32 realtics)
 	analogjoystickmove = cv_usejoystick.value && !Joystick.bGamepadStyle;
 	gamepadjoystickmove = cv_usejoystick.value && Joystick.bGamepadStyle;
 
-	// todo joystick-juggling next
-	//thisjoyaiming = (cv_chasecam.value) ? cv_chasefreelook.value : cv_alwaysfreelook.value;
-	thisjoyaiming = cv_alwaysfreelook.value;
+	thisjoyaiming = (cv_chasecam.value) ? cv_chasefreelook.value : cv_alwaysfreelook.value;
 
 	// Reset the vertical look if we're no longer joyaiming
 	if (!thisjoyaiming && joyaiming)
@@ -1289,9 +1287,7 @@ void G_BuildTiccmd2(ticcmd_t *cmd, INT32 realtics)
 	analogjoystickmove = cv_usejoystick2.value && !Joystick2.bGamepadStyle;
 	gamepadjoystickmove = cv_usejoystick2.value && Joystick2.bGamepadStyle;
 
-	// todo joystick-juggling next
-	//thisjoyaiming = (cv_chasecam.value) ? cv_chasefreelook2.value : cv_alwaysfreelook2.value;
-	thisjoyaiming = cv_alwaysfreelook2.value;
+	thisjoyaiming = (cv_chasecam2.value) ? cv_chasefreelook2.value : cv_alwaysfreelook2.value;
 
 	// Reset the vertical look if we're no longer joyaiming
 	if (!thisjoyaiming && joyaiming)

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -960,13 +960,14 @@ void G_BuildTiccmd(ticcmd_t *cmd, INT32 realtics)
 	INT32 tspeed, forward, side, axis, i;
 	const INT32 speed = 1;
 	// these ones used for multiple conditions
-	boolean turnleft, turnright, mouseaiming, joyaiming, analogjoystickmove, gamepadjoystickmove;
+	boolean turnleft, turnright, mouseaiming, analogjoystickmove, gamepadjoystickmove, thisjoyaiming;
 	player_t *player = &players[consoleplayer];
 	camera_t *thiscam = &camera;
 
 	static INT32 turnheld; // for accelerative turning
 	static boolean keyboard_look; // true if lookup/down using keyboard
 	static boolean resetdown; // don't cam reset every frame
+	static boolean joyaiming; // check the last frame's value if we need to reset the camera
 
 	G_CopyTiccmd(cmd, I_BaseTiccmd(), 1); // empty, or external driver
 
@@ -985,6 +986,15 @@ void G_BuildTiccmd(ticcmd_t *cmd, INT32 realtics)
 		(cv_chasecam.value ? cv_chasefreelook.value : cv_alwaysfreelook.value);
 	analogjoystickmove = cv_usejoystick.value && !Joystick.bGamepadStyle;
 	gamepadjoystickmove = cv_usejoystick.value && Joystick.bGamepadStyle;
+
+	// todo joystick-juggling next
+	//thisjoyaiming = (cv_chasecam.value) ? cv_chasefreelook.value : cv_alwaysfreelook.value;
+	thisjoyaiming = cv_alwaysfreelook.value;
+
+	// Reset the vertical look if we're no longer joyaiming
+	if (!thisjoyaiming && joyaiming)
+		localaiming = 0;
+	joyaiming = thisjoyaiming;
 
 	axis = JoyAxis(AXISTURN);
 	if (gamepadjoystickmove && axis != 0)
@@ -1252,13 +1262,14 @@ void G_BuildTiccmd2(ticcmd_t *cmd, INT32 realtics)
 	INT32 tspeed, forward, side, axis, i;
 	const INT32 speed = 1;
 	// these ones used for multiple conditions
-	boolean turnleft, turnright, mouseaiming, joyaiming, analogjoystickmove, gamepadjoystickmove;
+	boolean turnleft, turnright, mouseaiming, analogjoystickmove, gamepadjoystickmove, thisjoyaiming;
 	player_t *player = &players[secondarydisplayplayer];
 	camera_t *thiscam = (player->bot == 2 ? &camera : &camera2);
 
 	static INT32 turnheld; // for accelerative turning
 	static boolean keyboard_look; // true if lookup/down using keyboard
 	static boolean resetdown; // don't cam reset every frame
+	static boolean joyaiming; // check the last frame's value if we need to reset the camera
 
 	G_CopyTiccmd(cmd,  I_BaseTiccmd2(), 1); // empty, or external driver
 
@@ -1277,6 +1288,15 @@ void G_BuildTiccmd2(ticcmd_t *cmd, INT32 realtics)
 		(cv_chasecam2.value ? cv_chasefreelook2.value : cv_alwaysfreelook2.value);
 	analogjoystickmove = cv_usejoystick2.value && !Joystick2.bGamepadStyle;
 	gamepadjoystickmove = cv_usejoystick2.value && Joystick2.bGamepadStyle;
+
+	// todo joystick-juggling next
+	//thisjoyaiming = (cv_chasecam.value) ? cv_chasefreelook2.value : cv_alwaysfreelook2.value;
+	thisjoyaiming = cv_alwaysfreelook2.value;
+
+	// Reset the vertical look if we're no longer joyaiming
+	if (!thisjoyaiming && joyaiming)
+		localaiming2 = 0;
+	joyaiming = thisjoyaiming;
 
 	axis = Joy2Axis(AXISTURN);
 	if (gamepadjoystickmove && axis != 0)

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -387,7 +387,7 @@ consvar_t cv_lookaxis = {"joyaxis_look", "RStick.Y", CV_SAVE, joyaxis_cons_t, NU
 consvar_t cv_fireaxis = {"joyaxis_fire", "LAnalog", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
 consvar_t cv_firenaxis = {"joyaxis_firenormal", "RAnalog", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
 #else
-consvar_t cv_turnaxis = {"joyaxis_turn", "X-Axis", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
+consvar_t cv_turnaxis = {"joyaxis_turn", "X-Rudder", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
 #ifdef PSP
 consvar_t cv_moveaxis = {"joyaxis_move", "None", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
 #else
@@ -401,17 +401,17 @@ consvar_t cv_lookaxis = {"joyaxis_look", "Alt Y-Axis", CV_SAVE, joyaxis_cons_t, 
 #elif defined (PSP)
 consvar_t cv_sideaxis = {"joyaxis_side", "None", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
 #else
-consvar_t cv_sideaxis = {"joyaxis_side", "Z-Axis", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
+consvar_t cv_sideaxis = {"joyaxis_side", "X-Axis", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
 #endif
 #ifndef _XBOX
 #ifdef PSP
 consvar_t cv_lookaxis = {"joyaxis_look", "Y-Axis", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
 #else
-consvar_t cv_lookaxis = {"joyaxis_look", "None", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
+consvar_t cv_lookaxis = {"joyaxis_look", "Y-Rudder-", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
 #endif
 #endif
-consvar_t cv_fireaxis = {"joyaxis_fire", "None", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
-consvar_t cv_firenaxis = {"joyaxis_firenormal", "None", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
+consvar_t cv_fireaxis = {"joyaxis_fire", "Z-Axis", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
+consvar_t cv_firenaxis = {"joyaxis_firenormal", "Z-Axis-", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
 #endif
 
 #if defined (_WII) || defined  (WMINPUT)

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -960,7 +960,7 @@ void G_BuildTiccmd(ticcmd_t *cmd, INT32 realtics)
 	INT32 tspeed, forward, side, axis, i;
 	const INT32 speed = 1;
 	// these ones used for multiple conditions
-	boolean turnleft, turnright, mouseaiming, analogjoystickmove, gamepadjoystickmove;
+	boolean turnleft, turnright, mouseaiming, joyaiming, analogjoystickmove, gamepadjoystickmove;
 	player_t *player = &players[consoleplayer];
 	camera_t *thiscam = &camera;
 
@@ -1161,11 +1161,11 @@ void G_BuildTiccmd(ticcmd_t *cmd, INT32 realtics)
 		}
 
 		axis = JoyAxis(AXISLOOK);
-		if (analogjoystickmove && axis != 0 && cv_lookaxis.value != 0)
+		if (analogjoystickmove && joyaiming && axis != 0 && cv_lookaxis.value != 0)
 			localaiming += (axis<<16) * screen_invert;
 
 		// spring back if not using keyboard neither mouselookin'
-		if (!keyboard_look && cv_lookaxis.value == 0 && !mouseaiming)
+		if (!keyboard_look && cv_lookaxis.value == 0 && !joyaiming && !mouseaiming)
 			localaiming = 0;
 
 		if (PLAYER1INPUTDOWN(gc_lookup) || (gamepadjoystickmove && axis < 0))
@@ -1252,7 +1252,7 @@ void G_BuildTiccmd2(ticcmd_t *cmd, INT32 realtics)
 	INT32 tspeed, forward, side, axis, i;
 	const INT32 speed = 1;
 	// these ones used for multiple conditions
-	boolean turnleft, turnright, mouseaiming, analogjoystickmove, gamepadjoystickmove;
+	boolean turnleft, turnright, mouseaiming, joyaiming, analogjoystickmove, gamepadjoystickmove;
 	player_t *player = &players[secondarydisplayplayer];
 	camera_t *thiscam = (player->bot == 2 ? &camera : &camera2);
 
@@ -1450,11 +1450,11 @@ void G_BuildTiccmd2(ticcmd_t *cmd, INT32 realtics)
 		}
 
 		axis = Joy2Axis(AXISLOOK);
-		if (analogjoystickmove && axis != 0 && cv_lookaxis2.value != 0)
+		if (analogjoystickmove && joyaiming && axis != 0 && cv_lookaxis2.value != 0)
 			localaiming2 += (axis<<16) * screen_invert;
 
 		// spring back if not using keyboard neither mouselookin'
-		if (!keyboard_look && cv_lookaxis2.value == 0 && !mouseaiming)
+		if (!keyboard_look && cv_lookaxis2.value == 0 && !joyaiming && !mouseaiming)
 			localaiming2 = 0;
 
 		if (PLAYER2INPUTDOWN(gc_lookup) || (gamepadjoystickmove && axis < 0))

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -1090,10 +1090,8 @@ static menuitem_t OP_Joystick1Menu[] =
 	{IT_STRING | IT_CVAR,  NULL, "Axis For Firing"   , &cv_fireaxis         ,  70},
 	{IT_STRING | IT_CVAR,  NULL, "Axis For NFiring"  , &cv_firenaxis        ,  80},
 
-	// todo joystick-juggling next
-	// {IT_STRING | IT_CVAR, NULL, "First-Person Vert-Look", &cv_alwaysfreelook,   100},
-	// {IT_STRING | IT_CVAR, NULL, "Third-Person Vert-Look", &cv_chasefreelook,   110},
-	{IT_STRING | IT_CVAR, NULL, "Always Look Up/Down", &cv_alwaysfreelook,   100},
+	{IT_STRING | IT_CVAR, NULL, "First-Person Vert-Look", &cv_alwaysfreelook,   100},
+	{IT_STRING | IT_CVAR, NULL, "Third-Person Vert-Look", &cv_chasefreelook,   110},
 };
 
 static menuitem_t OP_Joystick2Menu[] =
@@ -1106,10 +1104,8 @@ static menuitem_t OP_Joystick2Menu[] =
 	{IT_STRING | IT_CVAR,  NULL, "Axis For Firing"   , &cv_fireaxis2        , 70},
 	{IT_STRING | IT_CVAR,  NULL, "Axis For NFiring"  , &cv_firenaxis2       , 80},
 
-	// todo joystick-juggling next
-	// {IT_STRING | IT_CVAR, NULL, "First-Person Vert-Look", &cv_alwaysfreelook2,   100},
-	// {IT_STRING | IT_CVAR, NULL, "Third-Person Vert-Look", &cv_chasefreelook2,   110},
-	{IT_STRING | IT_CVAR, NULL, "Always Look Up/Down", &cv_alwaysfreelook2,   100},
+	{IT_STRING | IT_CVAR, NULL, "First-Person Vert-Look", &cv_alwaysfreelook2,   100},
+	{IT_STRING | IT_CVAR, NULL, "Third-Person Vert-Look", &cv_chasefreelook2,   110},
 };
 
 static menuitem_t OP_JoystickSetMenu[] =

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -2079,44 +2079,44 @@ boolean M_Responder(event_t *ev)
 		// (but still allow shift keyup so caps doesn't get stuck)
 		return false;
 	}
-	else if (ev->type == ev_keydown)
-	{
-		ch = ev->data1;
-
-		// added 5-2-98 remap virtual keys (mouse & joystick buttons)
-		switch (ch)
-		{
-			case KEY_MOUSE1:
-			case KEY_JOY1:
-				ch = KEY_ENTER;
-				break;
-			case KEY_JOY1 + 3:
-				ch = 'n';
-				break;
-			case KEY_MOUSE1 + 1:
-			case KEY_JOY1 + 1:
-				ch = KEY_ESCAPE;
-				break;
-			case KEY_JOY1 + 2:
-				ch = KEY_BACKSPACE;
-				break;
-			case KEY_HAT1:
-				ch = KEY_UPARROW;
-				break;
-			case KEY_HAT1 + 1:
-				ch = KEY_DOWNARROW;
-				break;
-			case KEY_HAT1 + 2:
-				ch = KEY_LEFTARROW;
-				break;
-			case KEY_HAT1 + 3:
-				ch = KEY_RIGHTARROW;
-				break;
-		}
-	}
 	else if (menuactive)
 	{
-		if (ev->type == ev_joystick  && ev->data1 == 0 && joywait < I_GetTime())
+		if (ev->type == ev_keydown)
+		{
+			ch = ev->data1;
+
+			// added 5-2-98 remap virtual keys (mouse & joystick buttons)
+			switch (ch)
+			{
+				case KEY_MOUSE1:
+				case KEY_JOY1:
+					ch = KEY_ENTER;
+					break;
+				case KEY_JOY1 + 3:
+					ch = 'n';
+					break;
+				case KEY_MOUSE1 + 1:
+				case KEY_JOY1 + 1:
+					ch = KEY_ESCAPE;
+					break;
+				case KEY_JOY1 + 2:
+					ch = KEY_BACKSPACE;
+					break;
+				case KEY_HAT1:
+					ch = KEY_UPARROW;
+					break;
+				case KEY_HAT1 + 1:
+					ch = KEY_DOWNARROW;
+					break;
+				case KEY_HAT1 + 2:
+					ch = KEY_LEFTARROW;
+					break;
+				case KEY_HAT1 + 3:
+					ch = KEY_RIGHTARROW;
+					break;
+			}
+		}
+		else if (ev->type == ev_joystick  && ev->data1 == 0 && joywait < I_GetTime())
 		{
 			if (ev->data3 == -1)
 			{

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -223,7 +223,6 @@ static void M_SelectableClearMenus(INT32 choice);
 static void M_Retry(INT32 choice);
 static void M_EndGame(INT32 choice);
 static void M_MapChange(INT32 choice);
-static void M_Pause(INT32 choice);
 static void M_ChangeLevel(INT32 choice);
 static void M_ConfirmSpectate(INT32 choice);
 static void M_ConfirmEnterGame(INT32 choice);
@@ -479,8 +478,6 @@ typedef enum
 // ---------------------
 static menuitem_t MPauseMenu[] =
 {
-	{IT_STRING  | IT_CALL,    NULL, "Pause",             M_Pause,                0},
-
 	{IT_STRING  | IT_SUBMENU, NULL, "Scramble Teams...", &MISC_ScrambleTeamDef, 16},
 	{IT_STRING  | IT_CALL,    NULL, "Switch Map..."    , M_MapChange,           24},
 
@@ -500,8 +497,7 @@ static menuitem_t MPauseMenu[] =
 
 typedef enum
 {
-	mpause_pause = 0,
-	mpause_scramble,
+	mpause_scramble = 0,
 	mpause_switchmap,
 
 	mpause_continue,
@@ -2095,11 +2091,6 @@ boolean M_Responder(event_t *ev)
 		{
 			ch = ev->data1;
 
-			// Pause by joystick means you bring up the menu
-			if (ch >= KEY_JOY1 && ch < KEY_JOY1 + JOYBUTTONS + JOYHATS*4 &&
-				(ch == gamecontrol[gc_pause][0] || ch == gamecontrol[gc_pause][1]))
-				ch = KEY_ESCAPE;
-
 			// added 5-2-98 remap virtual keys (mouse & joystick buttons)
 			switch (ch)
 			{
@@ -2195,11 +2186,6 @@ boolean M_Responder(event_t *ev)
 	// F-Keys
 	if (!menuactive)
 	{
-		// Pause by joystick means you bring up the menu
-		if (ch >= KEY_JOY1 && ch < KEY_JOY1 + JOYBUTTONS + JOYHATS*4 &&
-			(ch == gamecontrol[gc_pause][0] || ch == gamecontrol[gc_pause][1]))
-			ch = KEY_ESCAPE;
-
 		noFurtherInput = true;
 		switch (ch)
 		{
@@ -2587,7 +2573,6 @@ void M_StartControlPanel(void)
 	}
 	else // multiplayer
 	{
-		MPauseMenu[mpause_pause].status = IT_DISABLED;
 		MPauseMenu[mpause_switchmap].status = IT_DISABLED;
 		MPauseMenu[mpause_scramble].status = IT_DISABLED;
 		MPauseMenu[mpause_psetupsplit].status = IT_DISABLED;
@@ -2600,15 +2585,8 @@ void M_StartControlPanel(void)
 		if ((server || adminplayer == consoleplayer))
 		{
 			MPauseMenu[mpause_switchmap].status = IT_STRING | IT_CALL;
-			if (!splitscreen)
-				MPauseMenu[mpause_pause].status = IT_STRING | IT_CALL; // server admin only
 			if (G_GametypeHasTeams())
-			{
 				MPauseMenu[mpause_scramble].status = IT_STRING | IT_SUBMENU;
-				MPauseMenu[mpause_pause].alphaKey = MPauseMenu[mpause_scramble].alphaKey - 16; // adjust y
-			}
-			else
-				MPauseMenu[mpause_pause].alphaKey = MPauseMenu[mpause_switchmap].alphaKey - 16; // adjust y
 		}
 
 		if (splitscreen)
@@ -6266,13 +6244,6 @@ static void M_MapChange(INT32 choice)
 
 	M_PrepareLevelSelect();
 	M_SetupNextMenu(&MISC_ChangeLevelDef);
-}
-
-static void M_Pause(INT32 choice)
-{
-	(void)choice;
-
-	COM_ImmedExecute("pause");
 }
 
 static void M_StartSplitServerMenu(INT32 choice)

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -2088,7 +2088,6 @@ boolean M_Responder(event_t *ev)
 		{
 			case KEY_MOUSE1:
 			case KEY_JOY1:
-			case KEY_JOY1 + 2:
 				ch = KEY_ENTER;
 				break;
 			case KEY_JOY1 + 3:
@@ -2096,6 +2095,9 @@ boolean M_Responder(event_t *ev)
 				break;
 			case KEY_MOUSE1 + 1:
 			case KEY_JOY1 + 1:
+				ch = KEY_ESCAPE;
+				break;
+			case KEY_JOY1 + 2:
 				ch = KEY_BACKSPACE;
 				break;
 			case KEY_HAT1:

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -2171,6 +2171,8 @@ boolean M_Responder(event_t *ev)
 			}
 		}
 	}
+	else if (ev->type == ev_keydown) // Preserve event for other responders
+		ch = ev->data1;
 
 	if (ch == -1)
 		return false;

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -1085,6 +1085,11 @@ static menuitem_t OP_Joystick1Menu[] =
 	{IT_STRING | IT_CVAR,  NULL, "Axis For Looking"  , &cv_lookaxis         ,  60},
 	{IT_STRING | IT_CVAR,  NULL, "Axis For Firing"   , &cv_fireaxis         ,  70},
 	{IT_STRING | IT_CVAR,  NULL, "Axis For NFiring"  , &cv_firenaxis        ,  80},
+
+	// todo joystick-juggling next
+	// {IT_STRING | IT_CVAR, NULL, "First-Person Vert-Look", &cv_alwaysfreelook,   100},
+	// {IT_STRING | IT_CVAR, NULL, "Third-Person Vert-Look", &cv_chasefreelook,   110},
+	{IT_STRING | IT_CVAR, NULL, "Always Look Up/Down", &cv_alwaysfreelook,   100},
 };
 
 static menuitem_t OP_Joystick2Menu[] =
@@ -1096,6 +1101,11 @@ static menuitem_t OP_Joystick2Menu[] =
 	{IT_STRING | IT_CVAR,  NULL, "Axis For Looking"  , &cv_lookaxis2        , 60},
 	{IT_STRING | IT_CVAR,  NULL, "Axis For Firing"   , &cv_fireaxis2        , 70},
 	{IT_STRING | IT_CVAR,  NULL, "Axis For NFiring"  , &cv_firenaxis2       , 80},
+
+	// todo joystick-juggling next
+	// {IT_STRING | IT_CVAR, NULL, "First-Person Vert-Look", &cv_alwaysfreelook2,   100},
+	// {IT_STRING | IT_CVAR, NULL, "Third-Person Vert-Look", &cv_chasefreelook2,   110},
+	{IT_STRING | IT_CVAR, NULL, "Always Look Up/Down", &cv_alwaysfreelook2,   100},
 };
 
 static menuitem_t OP_JoystickSetMenu[] =

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -223,6 +223,7 @@ static void M_SelectableClearMenus(INT32 choice);
 static void M_Retry(INT32 choice);
 static void M_EndGame(INT32 choice);
 static void M_MapChange(INT32 choice);
+static void M_Pause(INT32 choice);
 static void M_ChangeLevel(INT32 choice);
 static void M_ConfirmSpectate(INT32 choice);
 static void M_ConfirmEnterGame(INT32 choice);
@@ -478,6 +479,8 @@ typedef enum
 // ---------------------
 static menuitem_t MPauseMenu[] =
 {
+	{IT_STRING  | IT_CALL,    NULL, "Pause",             M_Pause,                0},
+
 	{IT_STRING  | IT_SUBMENU, NULL, "Scramble Teams...", &MISC_ScrambleTeamDef, 16},
 	{IT_STRING  | IT_CALL,    NULL, "Switch Map..."    , M_MapChange,           24},
 
@@ -497,7 +500,8 @@ static menuitem_t MPauseMenu[] =
 
 typedef enum
 {
-	mpause_scramble = 0,
+	mpause_pause = 0,
+	mpause_scramble,
 	mpause_switchmap,
 
 	mpause_continue,
@@ -2095,6 +2099,11 @@ boolean M_Responder(event_t *ev)
 		{
 			ch = ev->data1;
 
+			// Pause by joystick means you bring up the menu
+			if (ch >= KEY_JOY1 && ch < KEY_JOY1 + JOYBUTTONS + JOYHATS*4 &&
+				(ch == gamecontrol[gc_pause][0] || ch == gamecontrol[gc_pause][1]))
+				ch = KEY_ESCAPE;
+
 			// added 5-2-98 remap virtual keys (mouse & joystick buttons)
 			switch (ch)
 			{
@@ -2190,6 +2199,11 @@ boolean M_Responder(event_t *ev)
 	// F-Keys
 	if (!menuactive)
 	{
+		// Pause by joystick means you bring up the menu
+		if (ch >= KEY_JOY1 && ch < KEY_JOY1 + JOYBUTTONS + JOYHATS*4 &&
+			(ch == gamecontrol[gc_pause][0] || ch == gamecontrol[gc_pause][1]))
+			ch = KEY_ESCAPE;
+
 		noFurtherInput = true;
 		switch (ch)
 		{
@@ -2577,6 +2591,7 @@ void M_StartControlPanel(void)
 	}
 	else // multiplayer
 	{
+		MPauseMenu[mpause_pause].status = IT_DISABLED;
 		MPauseMenu[mpause_switchmap].status = IT_DISABLED;
 		MPauseMenu[mpause_scramble].status = IT_DISABLED;
 		MPauseMenu[mpause_psetupsplit].status = IT_DISABLED;
@@ -2589,8 +2604,15 @@ void M_StartControlPanel(void)
 		if ((server || adminplayer == consoleplayer))
 		{
 			MPauseMenu[mpause_switchmap].status = IT_STRING | IT_CALL;
+			if (!splitscreen)
+				MPauseMenu[mpause_pause].status = IT_STRING | IT_CALL; // server admin only
 			if (G_GametypeHasTeams())
+			{
 				MPauseMenu[mpause_scramble].status = IT_STRING | IT_SUBMENU;
+				MPauseMenu[mpause_pause].alphaKey = MPauseMenu[mpause_scramble].alphaKey - 16; // adjust y
+			}
+			else
+				MPauseMenu[mpause_pause].alphaKey = MPauseMenu[mpause_switchmap].alphaKey - 16; // adjust y
 		}
 
 		if (splitscreen)
@@ -6248,6 +6270,13 @@ static void M_MapChange(INT32 choice)
 
 	M_PrepareLevelSelect();
 	M_SetupNextMenu(&MISC_ChangeLevelDef);
+}
+
+static void M_Pause(INT32 choice)
+{
+	(void)choice;
+
+	COM_ImmedExecute("pause");
 }
 
 static void M_StartSplitServerMenu(INT32 choice)


### PR DESCRIPTION
* Menu: Map Joy 2 to menu back (escape)
* Menu: Map Joy 3 to control clear (backspace)
* Make M_Responder operate on `(ev->type == ev_keydown)` for joy/mouse inputs ONLY IF (menuactive) because joy/mouse buttons were triggering menu-specific keys in-game
* Change joystick axis defaults to 360-friendly values
    * Move with Left Stick; Camera with Right Stick; Ring Toss with Left Trigger; Normal Toss with Right Trigger
* Tie joystick vertical look to `cv_alwaysfreelook` and `cv_chasefreelook` (for next)
* Add joystick vertical look toggle to menu

Based on next because of M_Responder quirk fix and `cv_chasefreelook`