### PR TITLE
SDL: Force use DirectSound driver to fix wrong-pitch sound effects

### DIFF
--- a/src/sdl/mixer_sound.c
+++ b/src/sdl/mixer_sound.c
@@ -92,6 +92,12 @@ void I_StartupSound(void)
 {
 	I_Assert(!sound_started);
 
+#ifdef _WIN32
+	// Force DirectSound instead of WASAPI
+	// SDL 2.0.6+ defaults to the latter and it screws up our sound effects
+	SDL_setenv("SDL_AUDIODRIVER", "directsound", 1);
+#endif
+
 	// EE inits audio first so we're following along.
 	if (SDL_WasInit(SDL_INIT_AUDIO) == SDL_INIT_AUDIO)
 	{

--- a/src/sdl/sdl_sound.c
+++ b/src/sdl/sdl_sound.c
@@ -1186,11 +1186,11 @@ void I_StartupSound(void)
 	// Configure sound device
 	CONS_Printf("I_StartupSound:\n");
 
-	#ifdef _WIN32
-		// Force DirectSound instead of WASAPI
-		// SDL 2.0.6+ defaults to the latter and it screws up our sound effects
-		SDL_setenv("SDL_AUDIODRIVER", "directsound", 1);
-	#endif
+#ifdef _WIN32
+	// Force DirectSound instead of WASAPI
+	// SDL 2.0.6+ defaults to the latter and it screws up our sound effects
+	SDL_setenv("SDL_AUDIODRIVER", "directsound", 1);
+#endif
 
 	// EE inits audio first so we're following along.
 	if (SDL_WasInit(SDL_INIT_AUDIO) == SDL_INIT_AUDIO)

--- a/src/sdl/sdl_sound.c
+++ b/src/sdl/sdl_sound.c
@@ -1186,6 +1186,12 @@ void I_StartupSound(void)
 	// Configure sound device
 	CONS_Printf("I_StartupSound:\n");
 
+	#ifdef _WIN32
+		// Force DirectSound instead of WASAPI
+		// SDL 2.0.6+ defaults to the latter and it screws up our sound effects
+		SDL_setenv("SDL_AUDIODRIVER", "directsound", 1);
+	#endif
+
 	// EE inits audio first so we're following along.
 	if (SDL_WasInit(SDL_INIT_AUDIO) == SDL_INIT_AUDIO)
 		CONS_Printf("SDL Audio already started\n");


### PR DESCRIPTION
This fixes the sound pitch bugs described in [!373](https://git.magicalgirl.moe/STJr/SRB2/merge_requests/373). 

Context: SDL 2.0.6 switched to using WASAPI, which expects sound samples to be 32-bit floating point. We don't do that conversion in our sample handling, so this env var hack forces the old DirectSound driver.

It would be *better* to actually fix the sample handling, but this one-liner is quick and easy. I'm unaware of what benefits we would lose by doing this, because this is basically what the game was using before, with the 2.0.3 DLL.