### PR TITLE
Fix savegamename being improperly built

### DIFF
--- a/src/dehacked.c
+++ b/src/dehacked.c
@@ -3080,7 +3080,7 @@ static void readmaincfg(MYFILE *f)
 				strncpy(timeattackfolder, gamedatafilename, min(filenamelen, sizeof (timeattackfolder)));
 				timeattackfolder[min(filenamelen, sizeof (timeattackfolder) - 1)] = '\0';
 
-				strncpy(savegamename, timeattackfolder, strlen(timeattackfolder));
+				strcpy(savegamename, timeattackfolder);
 				strlcat(savegamename, "%u.ssg", sizeof(savegamename));
 				// can't use sprintf since there is %u in savegamename
 				strcatbf(savegamename, srb2home, PATHSEP);


### PR DESCRIPTION
…r copying timeattackfolderFixes the weird [savegame name path string issue](https://git.magicalgirl.moe/STJr/SRB2/uploads/e051de2db3a1369db520772b17bdf8d2/srb20028.png). All happens in `dehacked.c`, which overwrites the default SRB2 save path. Facts:

1. `timeattackname` is the game mod name truncated to 64 chars, so this is safe to append to `savegamename`
2. When overwriting `savegamename`, the old code used `strncpy(..., ..., strlen(timeattackname)`. This copies the whole of `timeattackname`, but NOT the null char
    * Therefore, if the previous `savegamename` was `C:\Users\MarcoZ\SRB2\srb2sav%u.ssg`, the new string becomes `sugoiers\MarcoZ\SRB2\srb2sav%u.ssg`. **THIS IS THE FAILURE POINT!**
3. When appending the `%u.ssg` piece, that's appended to the end of the OLD string
    * `sugoiers\MarcoZ\SRB2\srb2sav%u.ssg%u.ssg`
4. `srb2home` is appended to the beginning of this string, whether that's your default SRB2 dir or another folder.
    * `C:\Users\MarcoZ\SRB2\sugoiers\MarcoZ\SRB2\srb2sav%u.ssg%u.ssg`
5. The result save name:
    * `C:\Users\MarcoZ\SRB2\sugoiers\MarcoZ\SRB2\srb2sav0.ssg10.ssg` (don't know where the 10 comes from...)

This fix attacks step 2, where using `strcpy()` auto-adds the null char to the end of `timeattackname`. As `timeattackname` is 64 chars and hence shorter than `savegamename`, `strcpy()` is safe to use. 

All works correctly after that point: `savegamename` is now merely `sugoi`, and the template is now `C:\Users\MarcoZ\SRB2\sugoi%u.ssg`

Tested with srb2home paths both in the default SRB2 dir and in another folder.