### PR TITLE
Apply srb2home path to EXEC, SAVECONFIG, and debugfile

### DIFF
--- a/src/d_net.c
+++ b/src/d_net.c
@@ -27,6 +27,7 @@
 #include "d_clisrv.h"
 #include "z_zone.h"
 #include "i_tcp.h"
+#include "d_main.h" // srb2home
 
 //
 // NETWORKING
@@ -1374,12 +1375,12 @@ boolean D_CheckNetGame(void)
 		{
 			k++;
 			sprintf(filename, "debug%d.txt", k);
-			debugfile = fopen(filename, "w");
+			debugfile = fopen(va("%s" PATHSEP "%s", srb2home, filename), "w");
 		}
 		if (debugfile)
-			CONS_Printf(M_GetText("debug output to: %s\n"), filename);
+			CONS_Printf(M_GetText("debug output to: %s\n"), va("%s" PATHSEP "%s", srb2home, filename));
 		else
-			CONS_Alert(CONS_WARNING, M_GetText("cannot debug output to file %s!\n"), filename);
+			CONS_Alert(CONS_WARNING, M_GetText("cannot debug output to file %s!\n"), va("%s" PATHSEP "%s", srb2home, filename));
 	}
 #endif
 #endif

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -518,6 +518,7 @@ void M_FirstLoadConfig(void)
 void M_SaveConfig(const char *filename)
 {
 	FILE *f;
+	char *filepath;
 
 	// make sure not to write back the config until it's been correctly loaded
 	if (!gameconfig_loaded)
@@ -532,10 +533,14 @@ void M_SaveConfig(const char *filename)
 			return;
 		}
 
-		f = fopen(filename, "w");
+		// append srb2home to beginning of filename
+		// configfile already has this applied
+		filepath = va(pandf,srb2home, filename);
+
+		f = fopen(filepath, "w");
 		// change it only if valid
 		if (f)
-			strcpy(configfile, filename);
+			strcpy(configfile, filepath);
 		else
 		{
 			CONS_Alert(CONS_ERROR, M_GetText("Couldn't save game config file %s\n"), filename);

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -534,8 +534,11 @@ void M_SaveConfig(const char *filename)
 		}
 
 		// append srb2home to beginning of filename
-		// configfile already has this applied
-		filepath = va(pandf,srb2home, filename);
+		// but check if srb2home isn't already there, first
+		if (!strstr(filename, srb2home))
+			filepath = va(pandf,srb2home, filename);
+		else
+			filepath = Z_StrDup(filename);
 
 		f = fopen(filepath, "w");
 		// change it only if valid
@@ -543,7 +546,7 @@ void M_SaveConfig(const char *filename)
 			strcpy(configfile, filepath);
 		else
 		{
-			CONS_Alert(CONS_ERROR, M_GetText("Couldn't save game config file %s\n"), filename);
+			CONS_Alert(CONS_ERROR, M_GetText("Couldn't save game config file %s\n"), filepath);
 			return;
 		}
 	}


### PR DESCRIPTION
`srb2home` was missing from EXEC, SAVECONFIG, and debugfile, so those commands would look in the improper folders for Mac and Linux (and Windows, if `%userprofile%\SRB2` was being used. To test, move config.cfg to that path.)

Tests well with `srb2home` set to SRB2 install path as well as user profile folder.

It's worth noting that file finding is a MESS in the current code, and not at all centralized... I'm *pretty* sure these three cases are the only ones not already handled with `srb2home`.