### PR TITLE
Accept '+' as substitute for '\' for sprite frames (PK3)

### DIFF
--- a/src/r_things.h
+++ b/src/r_things.h
@@ -219,6 +219,7 @@ FUNCMATH FUNCINLINE static ATTRINLINE char R_Frame2Char(UINT8 frame)
 FUNCMATH FUNCINLINE static ATTRINLINE UINT8 R_Char2Frame(char cn)
 {
 #if 1 // 2.1 compat
+	if (cn == '+') return '\\' - 'A'; // PK3 can't use backslash, so use + instead
 	return cn - 'A';
 #else
 	if (cn >= 'A' && cn <= 'Z') return cn - 'A';


### PR DESCRIPTION
Modifies `R_Char2Frame()` to handle '+' as '\', upon [@toaster](https://git.magicalgirl.moe/toaster) 's suggestion. This sidesteps the PK3 limitation that lumps can't be named with backslash.

For reference, the ASCII sort order:

![image](https://git.magicalgirl.moe/STJr/SRB2/uploads/48c9f5fda565c84ca9a66b89ee1f6196/image.png)

2.1 takes any subsequent char from 'A' and numbers that as the frame number (`frame = char - 'A'`). This change simply returns `frame = '\\' - 'A'` if '+' is used.

Note that `R_Frame2Char()` will return backslash no matter what (`char = 'A' + '\\'`) because we discard the '+' substitute moniker. I don't think it's necessary to support both directions.

It's worth noting that ZDoom also does char substitution for PK3. From ZDoom Wiki:

```
Sprite lumps for the \ frame in a WAD (such as VILE\* for one of the Arch-Vile's healing frames) can be put in a ZIP file, the backslash character just has to be changed to a caret character (^). So, VILE^1 to VILE^8 in a ZIP file will be interpreted as the VILE\1 to VILE\8 lumps. This replacement only works for sprites, any other lump name should not contain backslashes anywhere.
```