### PR TITLE
WIP: Block exchndl.dll loading for XP/Vista users

### DIFF
--- a/src/sdl/i_main.c
+++ b/src/sdl/i_main.c
@@ -152,16 +152,11 @@ int main(int argc, char **argv)
 			// XP and Vista users can't use the newest exchndl.dll
 			// and older exchndl.dll won't work with release builds >= 2.1.21
 			// Check for >= Version 6.1 (>= Win7)
-#if defined(_INC_VERSIONHELPERS) || defined(_versionhelpers_H_INCLUDED_)
-			if (IsWindows7OrGreater())
-				LoadLibraryA("exchndl.dll");
-#else
 			DWORD winversion = GetVersion();
 			DWORD major = (DWORD)(LOBYTE(LOWORD(winversion)));
 			DWORD minor = (DWORD)(HIBYTE(LOWORD(winversion)));
 			if (major > 6 || (major == 6 && minor > 0))
 				LoadLibraryA("exchndl.dll");
-#endif
 		}
 	}
 #ifndef __MINGW32__

--- a/src/sdl/i_main.c
+++ b/src/sdl/i_main.c
@@ -149,7 +149,14 @@ int main(int argc, char **argv)
 			)
 #endif
 		{
-			LoadLibraryA("exchndl.dll");
+			// XP and Vista users can't use the newest exchndl.dll
+			// and older exchndl.dll won't work with release builds >= 2.1.21
+			// Check for >= Version 6.1 (>= Win7)
+			DWORD winversion = GetVersion();
+			DWORD major = (DWORD)(LOBYTE(LOWORD(winversion)));
+    		DWORD minor = (DWORD)(HIBYTE(LOWORD(winversion)));
+			if (major > 6 || (major == 6 && minor > 0))
+				LoadLibraryA("exchndl.dll");
 		}
 	}
 #ifndef __MINGW32__

--- a/src/sdl/i_main.c
+++ b/src/sdl/i_main.c
@@ -154,7 +154,7 @@ int main(int argc, char **argv)
 			// Check for >= Version 6.1 (>= Win7)
 			DWORD winversion = GetVersion();
 			DWORD major = (DWORD)(LOBYTE(LOWORD(winversion)));
-    		DWORD minor = (DWORD)(HIBYTE(LOWORD(winversion)));
+			DWORD minor = (DWORD)(HIBYTE(LOWORD(winversion)));
 			if (major > 6 || (major == 6 && minor > 0))
 				LoadLibraryA("exchndl.dll");
 		}

--- a/src/sdl/i_main.c
+++ b/src/sdl/i_main.c
@@ -152,11 +152,16 @@ int main(int argc, char **argv)
 			// XP and Vista users can't use the newest exchndl.dll
 			// and older exchndl.dll won't work with release builds >= 2.1.21
 			// Check for >= Version 6.1 (>= Win7)
+#if defined(_INC_VERSIONHELPERS) || defined(_versionhelpers_H_INCLUDED_)
+			if (IsWindows7OrGreater())
+				LoadLibraryA("exchndl.dll");
+#else
 			DWORD winversion = GetVersion();
 			DWORD major = (DWORD)(LOBYTE(LOWORD(winversion)));
 			DWORD minor = (DWORD)(HIBYTE(LOWORD(winversion)));
 			if (major > 6 || (major == 6 && minor > 0))
 				LoadLibraryA("exchndl.dll");
+#endif
 		}
 	}
 #ifndef __MINGW32__

--- a/src/sdl12/i_main.c
+++ b/src/sdl12/i_main.c
@@ -221,11 +221,16 @@ int main(int argc, char **argv)
 			// XP and Vista users can't use the newest exchndl.dll
 			// and older exchndl.dll won't work with release builds >= 2.1.21
 			// Check for >= Version 6.1 (>= Win7)
+#if defined(_INC_VERSIONHELPERS) || defined(_versionhelpers_H_INCLUDED_)
+			if (IsWindows7OrGreater())
+				LoadLibraryA("exchndl.dll");
+#else
 			DWORD winversion = GetVersion();
 			DWORD major = (DWORD)(LOBYTE(LOWORD(winversion)));
 			DWORD minor = (DWORD)(HIBYTE(LOWORD(winversion)));
 			if (major > 6 || (major == 6 && minor > 0))
 				LoadLibraryA("exchndl.dll");
+#endif
 		}
 	}
 #endif

--- a/src/sdl12/i_main.c
+++ b/src/sdl12/i_main.c
@@ -223,7 +223,7 @@ int main(int argc, char **argv)
 			// Check for >= Version 6.1 (>= Win7)
 			DWORD winversion = GetVersion();
 			DWORD major = (DWORD)(LOBYTE(LOWORD(winversion)));
-    		DWORD minor = (DWORD)(HIBYTE(LOWORD(winversion)));
+			DWORD minor = (DWORD)(HIBYTE(LOWORD(winversion)));
 			if (major > 6 || (major == 6 && minor > 0))
 				LoadLibraryA("exchndl.dll");
 		}

--- a/src/sdl12/i_main.c
+++ b/src/sdl12/i_main.c
@@ -221,16 +221,11 @@ int main(int argc, char **argv)
 			// XP and Vista users can't use the newest exchndl.dll
 			// and older exchndl.dll won't work with release builds >= 2.1.21
 			// Check for >= Version 6.1 (>= Win7)
-#if defined(_INC_VERSIONHELPERS) || defined(_versionhelpers_H_INCLUDED_)
-			if (IsWindows7OrGreater())
-				LoadLibraryA("exchndl.dll");
-#else
 			DWORD winversion = GetVersion();
 			DWORD major = (DWORD)(LOBYTE(LOWORD(winversion)));
 			DWORD minor = (DWORD)(HIBYTE(LOWORD(winversion)));
 			if (major > 6 || (major == 6 && minor > 0))
 				LoadLibraryA("exchndl.dll");
-#endif
 		}
 	}
 #endif

--- a/src/sdl12/i_main.c
+++ b/src/sdl12/i_main.c
@@ -218,7 +218,14 @@ int main(int argc, char **argv)
 #endif
 			)
 		{
-			LoadLibraryA("exchndl.dll");
+			// XP and Vista users can't use the newest exchndl.dll
+			// and older exchndl.dll won't work with release builds >= 2.1.21
+			// Check for >= Version 6.1 (>= Win7)
+			DWORD winversion = GetVersion();
+			DWORD major = (DWORD)(LOBYTE(LOWORD(winversion)));
+    		DWORD minor = (DWORD)(HIBYTE(LOWORD(winversion)));
+			if (major > 6 || (major == 6 && minor > 0))
+				LoadLibraryA("exchndl.dll");
 		}
 	}
 #endif

--- a/src/win32/win_main.c
+++ b/src/win32/win_main.c
@@ -668,11 +668,16 @@ int WINAPI WinMain (HINSTANCE hInstance,
 			// XP and Vista users can't use the newest exchndl.dll
 			// and older exchndl.dll won't work with release builds >= 2.1.21
 			// Check for >= Version 6.1 (Win7)
+#if defined(_INC_VERSIONHELPERS) || defined(_versionhelpers_H_INCLUDED_)
+			if (IsWindows7OrGreater())
+				LoadLibraryA("exchndl.dll");
+#else
 			DWORD winversion = GetVersion();
 			DWORD major = (DWORD)(LOBYTE(LOWORD(winversion)));
 			DWORD minor = (DWORD)(HIBYTE(LOWORD(winversion)));
 			if (major > 6 || (major == 6 && minor > 0))
 				LoadLibraryA("exchndl.dll");
+#endif
 #if 0
 		}
 #endif

--- a/src/win32/win_main.c
+++ b/src/win32/win_main.c
@@ -670,7 +670,7 @@ int WINAPI WinMain (HINSTANCE hInstance,
 			// Check for >= Version 6.1 (Win7)
 			DWORD winversion = GetVersion();
 			DWORD major = (DWORD)(LOBYTE(LOWORD(winversion)));
-    		DWORD minor = (DWORD)(HIBYTE(LOWORD(winversion)));
+			DWORD minor = (DWORD)(HIBYTE(LOWORD(winversion)));
 			if (major > 6 || (major == 6 && minor > 0))
 				LoadLibraryA("exchndl.dll");
 #if 0

--- a/src/win32/win_main.c
+++ b/src/win32/win_main.c
@@ -668,16 +668,11 @@ int WINAPI WinMain (HINSTANCE hInstance,
 			// XP and Vista users can't use the newest exchndl.dll
 			// and older exchndl.dll won't work with release builds >= 2.1.21
 			// Check for >= Version 6.1 (Win7)
-#if defined(_INC_VERSIONHELPERS) || defined(_versionhelpers_H_INCLUDED_)
-			if (IsWindows7OrGreater())
-				LoadLibraryA("exchndl.dll");
-#else
 			DWORD winversion = GetVersion();
 			DWORD major = (DWORD)(LOBYTE(LOWORD(winversion)));
 			DWORD minor = (DWORD)(HIBYTE(LOWORD(winversion)));
 			if (major > 6 || (major == 6 && minor > 0))
 				LoadLibraryA("exchndl.dll");
-#endif
 #if 0
 		}
 #endif

--- a/src/win32/win_main.c
+++ b/src/win32/win_main.c
@@ -663,8 +663,19 @@ int WINAPI WinMain (HINSTANCE hInstance,
 #endif
 		// Try Dr MinGW's exception handler.
 		if (!pfnIsDebuggerPresent || !pfnIsDebuggerPresent())
+		{
 #endif
-			LoadLibraryA("exchndl.dll");
+			// XP and Vista users can't use the newest exchndl.dll
+			// and older exchndl.dll won't work with release builds >= 2.1.21
+			// Check for >= Version 6.1 (Win7)
+			DWORD winversion = GetVersion();
+			DWORD major = (DWORD)(LOBYTE(LOWORD(winversion)));
+    		DWORD minor = (DWORD)(HIBYTE(LOWORD(winversion)));
+			if (major > 6 || (major == 6 && minor > 0))
+				LoadLibraryA("exchndl.dll");
+#if 0
+		}
+#endif
 
 #ifndef __MINGW32__
 		prevExceptionFilter = SetUnhandledExceptionFilter(RecordExceptionInfo);


### PR DESCRIPTION
See [#41](https://git.magicalgirl.moe/STJr/SRB2/issues/41) for discussion. Basically, the exchndl.dll bundled with 2.1.21 is too new for XP/Vista users. However, we cannot downgrade exchndl.dll because that would produce invalid RPT reports for our new release builds.

It seems the best option is to disallow exchndl.dll from being loaded if Windows is older than Win7. 

This means that XP/Vista users can't produce RPT files, but that userbase appears to be small anyway.

I'm unaware if this means Wine cannot load exchndl.dll either, or whether that even worked in the first place.