### PR TITLE
OpenGL z-fighting fix [by Azeonus]

### DIFF
--- a/src/hardware/hw_main.c
+++ b/src/hardware/hw_main.c
@@ -4333,7 +4333,17 @@ static void HWR_SplitSprite(gr_vissprite_t *spr)
 		wallVerts[3].tow = wallVerts[2].tow = 0;
 		wallVerts[0].tow = wallVerts[1].tow = gpatch->max_t;
 	}
-
+	
+	// if it has a dispoffset, push it a little towards the camera
+	if (spr->dispoffset) {
+		float co = -gr_viewcos*(0.05*spr->dispoffset);
+		float si = -gr_viewsin*(0.05*spr->dispoffset);
+		wallVerts[0].z = wallVerts[3].z = wallVerts[0].z+si;
+		wallVerts[1].z = wallVerts[2].z = wallVerts[1].z+si;
+		wallVerts[0].x = wallVerts[3].x = wallVerts[0].x+co;
+		wallVerts[1].x = wallVerts[2].x = wallVerts[1].x+co;
+	}
+	
 	realtop = top = wallVerts[3].y;
 	realbot = bot = wallVerts[0].y;
 	towtop = wallVerts[3].tow;
@@ -4634,7 +4644,17 @@ static void HWR_DrawSprite(gr_vissprite_t *spr)
 		////////////////////
 		HWR_DrawSpriteShadow(spr, gpatch, this_scale);
 	}
-
+	
+	// if it has a dispoffset, push it a little towards the camera
+	if (spr->dispoffset) {
+		float co = -gr_viewcos*(0.05*spr->dispoffset);
+		float si = -gr_viewsin*(0.05*spr->dispoffset);
+		wallVerts[0].z = wallVerts[3].z = wallVerts[0].z+si;
+		wallVerts[1].z = wallVerts[2].z = wallVerts[1].z+si;
+		wallVerts[0].x = wallVerts[3].x = wallVerts[0].x+co;
+		wallVerts[1].x = wallVerts[2].x = wallVerts[1].x+co;
+	}
+	
 	// This needs to be AFTER the shadows so that the regular sprites aren't drawn completely black.
 	// sprite lighting by modulating the RGB components
 	/// \todo coloured

--- a/src/hardware/hw_main.c
+++ b/src/hardware/hw_main.c
@@ -4333,17 +4333,17 @@ static void HWR_SplitSprite(gr_vissprite_t *spr)
 		wallVerts[3].tow = wallVerts[2].tow = 0;
 		wallVerts[0].tow = wallVerts[1].tow = gpatch->max_t;
 	}
-	
+
 	// if it has a dispoffset, push it a little towards the camera
 	if (spr->dispoffset) {
-		float co = -gr_viewcos*(0.05*spr->dispoffset);
-		float si = -gr_viewsin*(0.05*spr->dispoffset);
+		float co = -gr_viewcos*(0.05f*spr->dispoffset);
+		float si = -gr_viewsin*(0.05f*spr->dispoffset);
 		wallVerts[0].z = wallVerts[3].z = wallVerts[0].z+si;
 		wallVerts[1].z = wallVerts[2].z = wallVerts[1].z+si;
 		wallVerts[0].x = wallVerts[3].x = wallVerts[0].x+co;
 		wallVerts[1].x = wallVerts[2].x = wallVerts[1].x+co;
 	}
-	
+
 	realtop = top = wallVerts[3].y;
 	realbot = bot = wallVerts[0].y;
 	towtop = wallVerts[3].tow;
@@ -4644,17 +4644,17 @@ static void HWR_DrawSprite(gr_vissprite_t *spr)
 		////////////////////
 		HWR_DrawSpriteShadow(spr, gpatch, this_scale);
 	}
-	
+
 	// if it has a dispoffset, push it a little towards the camera
 	if (spr->dispoffset) {
-		float co = -gr_viewcos*(0.05*spr->dispoffset);
-		float si = -gr_viewsin*(0.05*spr->dispoffset);
+		float co = -gr_viewcos*(0.05f*spr->dispoffset);
+		float si = -gr_viewsin*(0.05f*spr->dispoffset);
 		wallVerts[0].z = wallVerts[3].z = wallVerts[0].z+si;
 		wallVerts[1].z = wallVerts[2].z = wallVerts[1].z+si;
 		wallVerts[0].x = wallVerts[3].x = wallVerts[0].x+co;
 		wallVerts[1].x = wallVerts[2].x = wallVerts[1].x+co;
 	}
-	
+
 	// This needs to be AFTER the shadows so that the regular sprites aren't drawn completely black.
 	// sprite lighting by modulating the RGB components
 	/// \todo coloured


### PR DESCRIPTION
Closes #43; fixes z-fighting for sprites with dispoffset in OpenGL. Even fixes for FOF (cutsprites). Thanks Azeonus!

![ogl-zfighting-fof](https://git.magicalgirl.moe/STJr/SRB2/uploads/508b75aa108748ccd13996447cb41df3/ogl-zfighting-fof.png)

![JealousConstantBrownbutterfly](https://git.magicalgirl.moe/STJr/SRB2/uploads/d35c427f56f198a7dbf79ca8ac5eec3c/JealousConstantBrownbutterfly.mp4)