### PR TITLE
Reset default controls for LOADCONFIG command

### DIFF
--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -442,6 +442,9 @@ void Command_LoadConfig_f(void)
 	strcpy(configfile, COM_Argv(1));
 	FIL_ForceExtension(configfile, ".cfg");
 
+	// load default control
+	G_Controldefault();
+
 	// temporarily reset execversion to default
 	cv_execversion.flags &= ~CV_HIDEN;
 	COM_BufInsertText(va("%s \"%s\"\n", cv_execversion.name, cv_execversion.defaultvalue));


### PR DESCRIPTION
The LOADCONFIG command doesn't reset the player controls to defaults, before running the cfg script. Theoretically, this means that if the cfg script is incomplete, the old controls can persist.

Objections? Is there a legitimate use case for LOADCONFIG'ing a partial cfg while intentionally keeping the old controls?

EDIT: Without this merge, the config updater won't be able to update the controls to add joypad defaults when using LOADCONFIG.