### PR TITLE
Center window on current monitor during vidmode change

### DIFF
--- a/src/sdl/i_video.c
+++ b/src/sdl/i_video.c
@@ -200,7 +200,10 @@ static void SDLSetMode(INT32 width, INT32 height, SDL_bool fullscreen)
 			}
 			// Reposition window only in windowed mode
 			SDL_SetWindowSize(window, width, height);
-			SDL_SetWindowPosition(window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
+			SDL_SetWindowPosition(window,
+				SDL_WINDOWPOS_CENTERED_DISPLAY(SDL_GetWindowDisplayIndex(window)),
+				SDL_WINDOWPOS_CENTERED_DISPLAY(SDL_GetWindowDisplayIndex(window))
+			);
 		}
 	}
 	else


### PR DESCRIPTION
Use `SDL_WINDOWPOS_CENTERED_DISPLAY(n)`, which is really the macro behind `SDL_WINDOWPOS_CENTERED`.

Guesstimation, pending testing.