### PR TITLE
Bot respawn fix

### DIFF
--- a/src/p_user.c
+++ b/src/p_user.c
@@ -7630,6 +7630,9 @@ static void P_DeathThink(player_t *player)
 	if (player->deadtimer < INT32_MAX)
 		player->deadtimer++;
 
+	if (player->bot) // don't allow bots to do any of the below, B_CheckRespawn does all they need for respawning already
+		goto notrealplayer;
+
 	// continue logic
 	if (!(netgame || multiplayer) && player->lives <= 0)
 	{
@@ -7748,6 +7751,8 @@ static void P_DeathThink(player_t *player)
 			}
 		}
 	}
+
+notrealplayer:
 
 	if (!player->mo)
 		return;


### PR DESCRIPTION
Fixes [#49](https://git.magicalgirl.moe/STJr/SRB2/issues/49). It turns out it's nothing to do with ultimate mode at all, but everything to do with the respawning-after-death code and how bots can apparently trigger it anyway if you get a GAME OVER. You have 0 lives, but the bot doesn't lose lives, you see.