### PR TITLE
Don't set window icon on Windows.

### DIFF
--- a/src/sdl/i_video.c
+++ b/src/sdl/i_video.c
@@ -42,9 +42,11 @@
 #ifdef HAVE_IMAGE
 #include "SDL_image.h"
 #elif 1
+#ifndef _WIN32
 #define LOAD_XPM //I want XPM!
 #include "IMG_xpm.c" //Alam: I don't want to add SDL_Image.dll/so
 #define HAVE_IMAGE //I have SDL_Image, sortof
+#endif
 #endif
 
 #ifdef HAVE_IMAGE


### PR DESCRIPTION
Don't set the window icon on Windows, as recent versions of SDL2 started doing it automatically using the icon embedded into the EXE. Should solve the icon quality being bad on taskbar.