### PR TITLE
Fix float comparison for colormap maskamt

### DIFF
--- a/src/r_data.c
+++ b/src/r_data.c
@@ -1220,7 +1220,7 @@ INT32 R_CreateColormap(char *p1, char *p2, char *p3)
 			continue;
 		if (maskcolor == extra_colormaps[i].maskcolor
 			&& fadecolor == extra_colormaps[i].fadecolor
-			&& fabsf((float)(maskamt - extra_colormaps[i].maskamt)) < 1.0E-36f
+			&& fabs(maskamt - extra_colormaps[i].maskamt) < 1.0E-36
 			&& fadestart == extra_colormaps[i].fadestart
 			&& fadeend == extra_colormaps[i].fadeend
 			&& fog == extra_colormaps[i].fog)


### PR DESCRIPTION
Welp, looks like we got our first regression from !375...

This code block compares a proposed colormap's `maskamt`, a double, to the list of existing colormaps' `maskamt`. If there's a match, then don't create a new colormap.

The old check failed in 32-bit release builds because the returned delta was greater than the compare value `1.0-E36`. This resulted in more colormaps being created than necessary -- in one case, crashing DSZ2 for exceeding `MAXCOLORMAPS`.

I thought about changing the comparison value, but then I figured that we don't need to cast `maskamt - extracolormaps[i].maskamt` to float when it's already a double.

So I just changed the comparison to a `double` and it now works. Tested in 32-bit release and debug builds; and 64-bit release and debug builds.

On another note, it may be worth considering a different compare value... DBL_EPSILON maybe?