### PR TITLE
MinGW64:Target nocona for 64-bit builds [revision]

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -104,7 +104,6 @@ endif
 ifdef LINUX64
 LINUX=1
 NONX86=1
-X86_64=1
 endif
 
 ifdef HAIKU

--- a/src/Makefile
+++ b/src/Makefile
@@ -104,7 +104,7 @@ endif
 ifdef LINUX64
 LINUX=1
 NONX86=1
-64BIT=1
+X86_64=1
 endif
 
 ifdef HAIKU
@@ -179,7 +179,7 @@ endif #ifdef MINGW
 
 ifdef MINGW64
 MINGW=1
-64BIT=1
+X86_64=1
 include win32/Makefile.cfg
 endif #ifdef MINGW64
 
@@ -296,7 +296,7 @@ else
 endif
 endif
 
-ifdef 64BIT
+ifdef X86_64
 	M5=-march=nocona
 endif
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -294,6 +294,9 @@ else
 	M5=-mpentium
 	M4=-m486
 endif
+else
+	M5=-march=nocona
+	M4=-mnocona
 endif
 
 ifndef NOASM

--- a/src/Makefile
+++ b/src/Makefile
@@ -104,7 +104,17 @@ endif
 ifdef LINUX64
 LINUX=1
 NONX86=1
+# LINUX64 does not imply X86_64=1; could mean ARM64 or Itanium
 endif
+
+ifdef MINGW64
+MINGW=1
+NONX86=1
+NOASM=1
+# MINGW64 should not necessarily imply X86_64=1, but we make that assumption elsewhere
+# Once that changes, remove this
+X86_64=1
+endif #ifdef MINGW64
 
 ifdef HAIKU
 SDL=1
@@ -175,12 +185,6 @@ endif
 ifdef MINGW
 include win32/Makefile.cfg
 endif #ifdef MINGW
-
-ifdef MINGW64
-MINGW=1
-X86_64=1
-include win32/Makefile.cfg
-endif #ifdef MINGW64
 
 ifdef UNIX
 UNIXCOMMON=1
@@ -289,14 +293,14 @@ OPTS += -DCOMPVERSION
 
 ifndef NONX86
 ifndef GCC29
-	M5=-march=pentium
+	M5?=-march=pentium
 else
-	M5=-mpentium
+	M5?=-mpentium
 endif
-endif
-
+else
 ifdef X86_64
-	M5=-march=nocona
+	M5?=-march=nocona
+endif
 endif
 
 ifndef NOASM

--- a/src/Makefile
+++ b/src/Makefile
@@ -104,6 +104,7 @@ endif
 ifdef LINUX64
 LINUX=1
 NONX86=1
+64BIT=1
 endif
 
 ifdef HAIKU
@@ -178,6 +179,7 @@ endif #ifdef MINGW
 
 ifdef MINGW64
 MINGW=1
+64BIT=1
 include win32/Makefile.cfg
 endif #ifdef MINGW64
 
@@ -289,14 +291,13 @@ OPTS += -DCOMPVERSION
 ifndef NONX86
 ifndef GCC29
 	M5=-march=pentium
-	M4=-march=i486
 else
 	M5=-mpentium
-	M4=-m486
 endif
-else
+endif
+
+ifdef 64BIT
 	M5=-march=nocona
-	M4=-mnocona
 endif
 
 ifndef NOASM

--- a/src/Makefile
+++ b/src/Makefile
@@ -293,13 +293,13 @@ OPTS += -DCOMPVERSION
 
 ifndef NONX86
 ifndef GCC29
-	M5?=-march=pentium
+	ARCHOPTS?=-march=pentium
 else
-	M5?=-mpentium
+	ARCHOPTS?=-mpentium
 endif
 else
 ifdef X86_64
-	M5?=-march=nocona
+	ARCHOPTS?=-march=nocona
 endif
 endif
 
@@ -428,7 +428,7 @@ else
 	WINDRESFLAGS = -DNDEBUG
 	CFLAGS+=-O3
 endif
-	CFLAGS+=-g $(OPTS) $(M5) $(WINDRESFLAGS)
+	CFLAGS+=-g $(OPTS) $(ARCHOPTS) $(WINDRESFLAGS)
 
 ifdef YASM
 ifdef STABS
@@ -916,15 +916,15 @@ endif
 ifndef NOHS
 $(OBJDIR)/s_ds3d.o: hardware/s_ds3d/s_ds3d.c hardware/hw3dsdrv.h \
  hardware/hw_dll.h
-	$(CC) $(M5) -Os -o $(OBJDIR)/s_ds3d.o $(WFLAGS) -D_WINDOWS -mwindows -c hardware/s_ds3d/s_ds3d.c
+	$(CC) $(ARCHOPTS) -Os -o $(OBJDIR)/s_ds3d.o $(WFLAGS) -D_WINDOWS -mwindows -c hardware/s_ds3d/s_ds3d.c
 
 $(OBJDIR)/s_fmod.o: hardware/s_openal/s_openal.c hardware/hw3dsdrv.h \
  hardware/hw_dll.h
-	$(CC) $(M5) -Os -o $(OBJDIR)/s_fmod.o $(WFLAGS) -D_WINDOWS -mwindows -c hardware/s_fmod/s_fmod.c
+	$(CC) $(ARCHOPTS) -Os -o $(OBJDIR)/s_fmod.o $(WFLAGS) -D_WINDOWS -mwindows -c hardware/s_fmod/s_fmod.c
 
 $(OBJDIR)/s_openal.o: hardware/s_openal/s_openal.c hardware/hw3dsdrv.h \
  hardware/hw_dll.h
-	$(CC) $(M5) -Os -o $(OBJDIR)/s_openal.o $(WFLAGS) -D_WINDOWS -mwindows -c hardware/s_openal/s_openal.c
+	$(CC) $(ARCHOPTS) -Os -o $(OBJDIR)/s_openal.o $(WFLAGS) -D_WINDOWS -mwindows -c hardware/s_openal/s_openal.c
 endif
 endif
 endif
@@ -954,11 +954,11 @@ else
 
 $(OBJDIR)/s_fmod.o: hardware/s_fmod/s_fmod.c hardware/hw3dsdrv.h \
  hardware/hw_dll.h
-	$(CC) $(M5) -Os -o $(OBJDIR)/s_fmod.o -DHW3SOUND -DUNIXCOMMON -shared -nostartfiles -c hardware/s_fmod/s_fmod.c
+	$(CC) $(ARCHOPTS) -Os -o $(OBJDIR)/s_fmod.o -DHW3SOUND -DUNIXCOMMON -shared -nostartfiles -c hardware/s_fmod/s_fmod.c
 
 $(OBJDIR)/s_openal.o: hardware/s_openal/s_openal.c hardware/hw3dsdrv.h \
  hardware/hw_dll.h
-	$(CC) $(M5) -Os -o $(OBJDIR)/s_openal.o -DHW3SOUND -DUNIXCOMMON -shared -nostartfiles -c hardware/s_openal/s_openal.c
+	$(CC) $(ARCHOPTS) -Os -o $(OBJDIR)/s_openal.o -DHW3SOUND -DUNIXCOMMON -shared -nostartfiles -c hardware/s_openal/s_openal.c
 endif
 
 ifdef FILTERS

--- a/src/win32/Makefile.cfg
+++ b/src/win32/Makefile.cfg
@@ -7,8 +7,6 @@
 #
 
 ifdef MINGW64
-	NOASM=1
-	NONX86=1
 	HAVE_LIBGME=1
 	LIBGME_CFLAGS=-I../libs/gme/include
 	LIBGME_LDFLAGS=-L../libs/gme/win64 -lgme


### PR DESCRIPTION
Revision of [!438 ](https://git.magicalgirl.moe/STJr/SRB2/merge_requests/438)

Per discussion, `-march=nocona` is only set when `X86_64=1`. `LINUX64=1` does not set this flag. 

`MINGW64=1` *does* currently set this flag, but only because we assume x86-64 in `src/win32/makefile.cfg`. If we stop assuming x86-64 in the future, then `X86_64` should not be set by `MINGW64` at that time.

`M5` is also renamed to `ARCHOPTS` and can be overridden by command line.