### PR TITLE
Some few changes to libopenmpt branch

### DIFF
--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -42,10 +42,6 @@ extern INT32 msg_id;
 #include "lua_hook.h" // MusicChange hook
 #endif
 
-#ifdef HAVE_OPENMPT
-#include "libopenmpt/libopenmpt.h"
-#endif
-
 #ifdef HW3SOUND
 // 3D Sound Interface
 #include "hardware/hw3sound.h"
@@ -62,6 +58,8 @@ static void Command_RestartAudio_f(void);
 static void GameMIDIMusic_OnChange(void);
 static void GameSounds_OnChange(void);
 static void GameDigiMusic_OnChange(void);
+
+static void ModFilter_OnChange(void);
 
 // commands for music and sound servers
 #ifdef MUSSERV
@@ -114,7 +112,7 @@ consvar_t cv_gamesounds = {"sounds", "On", CV_SAVE|CV_CALL|CV_NOINIT, CV_OnOff, 
 
 #ifdef HAVE_OPENMPT
 static CV_PossibleValue_t interpolationfilter_cons_t[] = {{0, "Default"}, {1, "None"}, {2, "Linear"}, {4, "Cubic"}, {8, "Windowed sinc"}, {0, NULL}};
-consvar_t cv_modfilter = {"modfilter", "0", CV_SAVE, interpolationfilter_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
+consvar_t cv_modfilter = {"modfilter", "0", CV_SAVE|CV_CALL, interpolationfilter_cons_t, ModFilter_OnChange, 0, NULL, NULL, 0, 0, NULL};
 #endif
 
 #define S_MAX_VOLUME 127
@@ -280,11 +278,6 @@ void S_RegisterSoundStuff(void)
 
 	COM_AddCommand("tunes", Command_Tunes_f);
 	COM_AddCommand("restartaudio", Command_RestartAudio_f);
-
-
-#ifdef HAVE_OPENMPT
-	CV_RegisterVar(&cv_modfilter);
-#endif
 
 #if defined (macintosh) && !defined (HAVE_SDL) // mp3 playlist stuff
 	{
@@ -1854,4 +1847,10 @@ void GameMIDIMusic_OnChange(void)
 			}
 		}
 	}
+}
+
+void ModFilter_OnChange(void)
+{
+	if (mod)
+		openmpt_module_set_render_param(mod, OPENMPT_MODULE_RENDER_INTERPOLATIONFILTER_LENGTH, cv_modfilter.value);
 }

--- a/src/s_sound.h
+++ b/src/s_sound.h
@@ -20,6 +20,11 @@
 #include "command.h"
 #include "tables.h" // angle_t
 
+#ifdef HAVE_OPENMPT
+#include "libopenmpt/libopenmpt.h"
+openmpt_module *mod;
+#endif
+
 // mask used to indicate sound origin is player item pickup
 #define PICKUP_SOUND 0x8000
 


### PR DESCRIPTION
All: A limiter was applied so the music don't get disorted with certain formats. Add missing MUS_FLAC case to the switch statement.

libopenmpt: Only call ```openmpt_module_set_repeat_count(mod, -1)`` if ``looping`` is set. Move openmpt_module_set_render_param out of the mix hook and into I_PlaySong and modfilter cvar, so it can apply on song playback and cvar value change.