### PR TITLE
Pk3 fixes

### DIFF
--- a/src/w_wad.c
+++ b/src/w_wad.c
@@ -588,6 +588,10 @@ static lumpinfo_t* ResGetLumpsZip (FILE* handle, UINT16* nlmp)
 			free(fullname);
 			return NULL;
 		}
+		
+		//If there any extra field or comments, skip them.
+		if(zentry->xtralen+zentry->commlen)
+			fseek(handle,zentry->xtralen+zentry->commlen,SEEK_CUR);
 
 		// Strip away file address and extension for the 8char name.
 		if ((trimname = strrchr(fullname, '/')) != 0)

--- a/src/w_wad.c
+++ b/src/w_wad.c
@@ -523,6 +523,7 @@ static lumpinfo_t* ResGetLumpsZip (FILE* handle, UINT16* nlmp)
     zlentry_t zlentry;
     zentry_t* zentries;
     zentry_t* zentry;
+    long oldpos;
 
 	UINT16 numlumps = *nlmp;
 	lumpinfo_t* lumpinfo;
@@ -574,7 +575,7 @@ static lumpinfo_t* ResGetLumpsZip (FILE* handle, UINT16* nlmp)
 			return NULL;
 		}
 		
-		long oldpos = ftell(handle);
+		oldpos = ftell(handle);
 		
 		fseek(handle,zentry->offset,SEEK_SET);
 		if(fread(&zlentry,1,sizeof(zlentry_t), handle) < sizeof(zlentry_t))

--- a/src/w_wad.c
+++ b/src/w_wad.c
@@ -189,7 +189,6 @@ static inline void W_LoadDehackedLumpsPK3(UINT16 wadnum)
 	if (posStart != INT16_MAX)
 	{
 		posEnd = W_CheckNumForFolderEndPK3("Lua/", wadnum, posStart);
-		posStart++;
 		for (; posStart < posEnd; posStart++)
 			LUA_LoadLump(wadnum, posStart);
 	}
@@ -197,7 +196,6 @@ static inline void W_LoadDehackedLumpsPK3(UINT16 wadnum)
 	if (posStart != INT16_MAX)
 	{
 		posEnd = W_CheckNumForFolderEndPK3("SOC/", wadnum, posStart);
-		posStart++;
 		for(; posStart < posEnd; posStart++)
 		{
 			lumpinfo_t *lump_p = &wadfiles[wadnum]->lumpinfo[posStart];
@@ -946,7 +944,7 @@ UINT16 W_CheckNumForFolderStartPK3(const char *name, UINT16 wad, UINT16 startlum
 	lumpinfo_t *lump_p = wadfiles[wad]->lumpinfo + startlump;
 	for (i = startlump; i < wadfiles[wad]->numlumps; i++, lump_p++)
 	{
-		if (strnicmp(name, lump_p->name2, strlen(name)) == 0)
+		if (!strnicmp(name, lump_p->name2, strlen(name)) && strlen(lump_p->name2) > strlen(name))
 			break;
 	}
 	return i;
@@ -1047,7 +1045,7 @@ lumpnum_t W_CheckNumForMap(const char *name)
 			else
 				continue;
 			// Now look for the specified map.
-			for (++lumpNum; lumpNum < end; lumpNum++)
+			for (; lumpNum < end; lumpNum++)
 				if (!strnicmp(name, (wadfiles[i]->lumpinfo + lumpNum)->name, 8))
 					return (i<<16) + lumpNum;
 		}


### PR DESCRIPTION
Here is a summary:
1) Add checking of extra fields and comments on zip files because otherwise the parser would mess up if present.

2)Fix the scanning of directories for function W_CheckNumForFolderStartPK3 since it skipped files built with zip archives other than slade.