### PR TITLE
Makefile: Target Pentium 4 by default for 32-bit builds

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -293,7 +293,7 @@ OPTS += -DCOMPVERSION
 
 ifndef NONX86
 ifndef GCC29
-	ARCHOPTS?=-march=pentium
+	ARCHOPTS?="-march=prescott -mfpmath=sse"
 else
 	ARCHOPTS?=-mpentium
 endif


### PR DESCRIPTION
This just changes the Makefile to target Pentium 4 CPUs by default for 32-bit, due to benchmark results (see comment). 

Historically, the Makefile has targeted Pentium 1 instructions. This change makes it so that Pentium 4 instructions are allowed, which could improve performance. It also enables SSE floating point math, which can improve OpenGL performance.

`ARCHOPTS?="-march=prescott -mfpmath=sse"`

For GCC compatibility:

* `-mfpmath=sse` is valid beginning GCC 3.1
* `-march=pentium4` is valid beginning GCC 3.2
* `-march=prescott` is valid beginning GCC 3.3

GCC 2.9 continues to use `-mpentium`.