### PR TITLE
Disable the APNG code if the version of libpng is greater than 1.4.

### DIFF
--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -93,7 +93,9 @@ typedef off_t off64_t;
  #ifdef PNG_WRITE_SUPPORTED
   #define USE_PNG // Only actually use PNG if write is supported.
   #if defined (PNG_WRITE_APNG_SUPPORTED) //|| !defined(PNG_STATIC)
-   #define USE_APNG
+   #if (PNG_LIBPNG_VER_MAJOR) == 1 && (PNG_LIBPNG_VER_MINOR <= 4) // Supposedly, the current APNG code can't work on newer versions as is
+    #define USE_APNG
+   #endif
   #endif
   // See hardware/hw_draw.c for a similar check to this one.
  #endif


### PR DESCRIPTION
Since supposedly the current code *can't* work with newer versions of libpng that have the apng patch, it won't compile if that's what people have.
It seems like some Linux distros are adding the apng patch to libpng and that'll make things annoying to compile for people.
I think it goes without saying, but if there's ever a fix to make newer libpng versions work with the APNG code then this can be reverted.