### PR TITLE
Tails bot dead forever fix

### DIFF
--- a/src/p_user.c
+++ b/src/p_user.c
@@ -8688,8 +8688,11 @@ void P_PlayerThink(player_t *player)
 
 	if (player->bot)
 	{
-		if (player->playerstate == PST_LIVE && B_CheckRespawn(player))
-			player->playerstate = PST_REBORN;
+		if (player->playerstate == PST_LIVE || player->playerstate == PST_DEAD)
+		{
+			if (B_CheckRespawn(player))
+				player->playerstate = PST_REBORN;
+		}
 		if (player->playerstate == PST_REBORN)
 			return;
 	}


### PR DESCRIPTION
Fixed the Tails bot not respawning after death. This was because of an oversight of mine made when I made the fix in [423](https://git.magicalgirl.moe/STJr/SRB2/merge_requests/423) last year; I thought Tails's respawn checking code ran when he was dead, but apparently not!