### PR TITLE
Translation map variable for modding use in mobj_t

### DIFF
--- a/src/hardware/hw_main.c
+++ b/src/hardware/hw_main.c
@@ -5603,6 +5603,9 @@ static void HWR_ProjectSprite(mobj_t *thing)
 		// bodge support - not nearly as comprehensive as r_things.c, but better than nothing
 		if (! R_ThingVisible(thing->tracer))
 			return;
+
+		thing->colorized = thing->tracer->colorized;
+		thing->tcforce = thing->tracer->tcforce;
 	}
 
 	// store information in a vissprite
@@ -5624,7 +5627,11 @@ static void HWR_ProjectSprite(mobj_t *thing)
 	vis->z2 = z2;
 
 	//Hurdler: 25/04/2000: now support colormap in hardware mode
-	if ((vis->mobj->flags & (MF_ENEMY|MF_BOSS)) && (vis->mobj->flags2 & MF2_FRET) && !(vis->mobj->flags & MF_GRENADEBOUNCE) && (leveltime & 1)) // Bosses "flash"
+	if (vis->mobj->tcforce) // force a specific translation map
+	{
+		vis->colormap = R_GetTranslationColormap(vis->mobj->tcforce, vis->mobj->color, GTC_CACHE);
+	}
+	else if ((vis->mobj->flags & (MF_ENEMY|MF_BOSS)) && (vis->mobj->flags2 & MF2_FRET) && !(vis->mobj->flags & MF_GRENADEBOUNCE) && (leveltime & 1)) // Bosses "flash"
 	{
 		if (vis->mobj->type == MT_CYBRAKDEMON || vis->mobj->colorized)
 			vis->colormap = R_GetTranslationColormap(TC_ALLWHITE, 0, GTC_CACHE);

--- a/src/hardware/hw_md2.c
+++ b/src/hardware/hw_md2.c
@@ -1327,7 +1327,11 @@ boolean HWR_DrawModel(gr_vissprite_t *spr)
 		{
 			INT32 skinnum = TC_DEFAULT;
 
-			if ((spr->mobj->flags & (MF_ENEMY|MF_BOSS)) && (spr->mobj->flags2 & MF2_FRET) && !(spr->mobj->flags & MF_GRENADEBOUNCE) && (leveltime & 1)) // Bosses "flash"
+			if (spr->mobj->tcforce) // force a specific translation map
+			{
+				skinnum = spr->mobj->tcforce;
+			}
+			else if ((spr->mobj->flags & (MF_ENEMY|MF_BOSS)) && (spr->mobj->flags2 & MF2_FRET) && !(spr->mobj->flags & MF_GRENADEBOUNCE) && (leveltime & 1)) // Bosses "flash"
 			{
 				if (spr->mobj->type == MT_CYBRAKDEMON || spr->mobj->colorized)
 					skinnum = TC_ALLWHITE;

--- a/src/lua_mobjlib.c
+++ b/src/lua_mobjlib.c
@@ -89,7 +89,8 @@ enum mobj_e {
 	mobj_standingslope,
 #endif
 	mobj_colorized,
-	mobj_shadowscale
+	mobj_shadowscale,
+	mobj_tcforce
 };
 
 static const char *const mobj_opt[] = {
@@ -158,6 +159,7 @@ static const char *const mobj_opt[] = {
 #endif
 	"colorized",
 	"shadowscale",
+	"tcforce",
 	NULL};
 
 #define UNIMPLEMENTED luaL_error(L, LUA_QL("mobj_t") " field " LUA_QS " is not implemented for Lua and cannot be accessed.", mobj_opt[field])
@@ -394,6 +396,9 @@ static int mobj_get(lua_State *L)
 		break;
 	case mobj_shadowscale:
 		lua_pushfixed(L, mo->shadowscale);
+		break;
+	case mobj_tcforce:
+		lua_pushinteger(L, mo->tcforce);
 		break;
 	default: // extra custom variables in Lua memory
 		lua_getfield(L, LUA_REGISTRYINDEX, LREG_EXTVARS);
@@ -726,6 +731,9 @@ static int mobj_set(lua_State *L)
 		break;
 	case mobj_shadowscale:
 		mo->shadowscale = luaL_checkfixed(L, 3);
+		break;
+	case mobj_tcforce:
+		mo->tcforce = luaL_checkinteger(L, 3);
 		break;
 	default:
 		lua_getfield(L, LUA_REGISTRYINDEX, LREG_EXTVARS);

--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -10599,6 +10599,8 @@ mobj_t *P_SpawnMobj(fixed_t x, fixed_t y, fixed_t z, mobjtype_t type)
 	mobj->scale = FRACUNIT;
 	mobj->destscale = mobj->scale;
 	mobj->scalespeed = FRACUNIT/12;
+	
+	mobj->tcforce = 0;
 
 	// TODO: Make this a special map header
 	if ((maptol & TOL_ERZ3) && !(mobj->type == MT_BLACKEGGMAN))

--- a/src/p_mobj.h
+++ b/src/p_mobj.h
@@ -376,6 +376,7 @@ typedef struct mobj_s
 
 	boolean colorized; // Whether the mobj uses the rainbow colormap
 	fixed_t shadowscale; // If this object casts a shadow, and the size relative to radius
+	INT32 tcforce; // Force a specific translation map
 
 	// WARNING: New fields must be added separately to savegame and Lua.
 } mobj_t;

--- a/src/p_saveg.c
+++ b/src/p_saveg.c
@@ -1258,6 +1258,7 @@ typedef enum
 	MD2_COLORIZED    = 1<<12,
 	MD2_ROLLANGLE    = 1<<13,
 	MD2_SHADOWSCALE  = 1<<14,
+	MD2_TCFORCE      = 1<<15,
 } mobj_diff2_t;
 
 typedef enum
@@ -1481,6 +1482,8 @@ static void SaveMobjThinker(const thinker_t *th, const UINT8 type)
 		diff2 |= MD2_ROLLANGLE;
 	if (mobj->shadowscale)
 		diff2 |= MD2_SHADOWSCALE;
+	if (mobj->tcforce)
+		diff2 |= MD2_TCFORCE;
 	if (diff2 != 0)
 		diff |= MD_MORE;
 
@@ -1649,6 +1652,8 @@ static void SaveMobjThinker(const thinker_t *th, const UINT8 type)
 		WRITEANGLE(save_p, mobj->rollangle);
 	if (diff2 & MD2_SHADOWSCALE)
 		WRITEFIXED(save_p, mobj->shadowscale);
+	if (diff2 & MD2_TCFORCE)
+		WRITEINT32(save_p, mobj->tcforce);
 
 	WRITEUINT32(save_p, mobj->mobjnum);
 }
@@ -2730,6 +2735,8 @@ static thinker_t* LoadMobjThinker(actionf_p1 thinker)
 		mobj->rollangle = READANGLE(save_p);
 	if (diff2 & MD2_SHADOWSCALE)
 		mobj->shadowscale = READFIXED(save_p);
+	if (diff2 & MD2_TCFORCE)
+		mobj->tcforce = READINT32(save_p);
 
 	if (diff & MD_REDFLAG)
 	{

--- a/src/p_user.c
+++ b/src/p_user.c
@@ -2034,6 +2034,7 @@ mobj_t *P_SpawnGhostMobj(mobj_t *mobj)
 
 	ghost->color = mobj->color;
 	ghost->colorized = mobj->colorized; // alternatively, "true" for sonic advance style colourisation
+	ghost->tcforce = mobj->tcforce;
 
 	ghost->angle = (mobj->player ? mobj->player->drawangle : mobj->angle);
 	ghost->sprite = mobj->sprite;

--- a/src/r_draw.c
+++ b/src/r_draw.c
@@ -544,6 +544,12 @@ static void R_GenerateTranslationColormap(UINT8 *dest_colormap, INT32 skinnum, U
 {
 	INT32 i, starttranscolor, skinramplength;
 
+	if (skinnum >= numskins || skinnum <= (TC_DEFAULT-7))
+	{
+		CONS_Alert(CONS_WARNING, "R_GenerateTranslationColormap called with invalid skinnum %d\n", skinnum);
+		skinnum = TC_DEFAULT;
+	}
+		
 	// Handle a couple of simple special cases
 	if (skinnum < TC_DEFAULT)
 	{

--- a/src/r_things.c
+++ b/src/r_things.c
@@ -770,7 +770,21 @@ static void R_DrawVisSprite(vissprite_t *vis)
 
 	colfunc = colfuncs[BASEDRAWFUNC]; // hack: this isn't resetting properly somewhere.
 	dc_colormap = vis->colormap;
-	if (!(vis->cut & SC_PRECIP) && (vis->mobj->flags & (MF_ENEMY|MF_BOSS)) && (vis->mobj->flags2 & MF2_FRET) && !(vis->mobj->flags & MF_GRENADEBOUNCE) && (leveltime & 1)) // Bosses "flash"
+
+	if (!(vis->cut & SC_PRECIP) && (vis->mobj->tcforce)) // force a specific translation map
+	{
+		if (vis->transmap)
+		{
+			colfunc = colfuncs[COLDRAWFUNC_TRANSTRANS];
+			dc_transmap = vis->transmap;
+		}
+		else
+		{
+			colfunc = colfuncs[COLDRAWFUNC_TRANS];
+		}
+		dc_translation = R_GetTranslationColormap(vis->mobj->tcforce, vis->mobj->color, GTC_CACHE);
+	}
+	else if (!(vis->cut & SC_PRECIP) && (vis->mobj->flags & (MF_ENEMY|MF_BOSS)) && (vis->mobj->flags2 & MF2_FRET) && !(vis->mobj->flags & MF_GRENADEBOUNCE) && (leveltime & 1)) // Bosses "flash"
 	{
 		// translate certain pixels to white
 		colfunc = colfuncs[COLDRAWFUNC_TRANS];


### PR DESCRIPTION
Adds support for mobj variable tcforce, intended to be set to any of the TC_ constants (TC_RAINBOW, TC_BLINK, etc.) and will override other hardcoded translation maps when set.

Minor improvement to MF2_LINKDRAW in OpenGL - object will inherit colorized and tcforce variables from tracer.

Error handling in R_GenerateTranslationColormap to cover any silly things a Lua scripter may throw at it.