### PR TITLE
Add `-splitscreen` commandline parameter

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1583,6 +1583,12 @@ void D_SRB2Main(void)
 		ultimatemode = true;
 	}
 
+	if (M_CheckParm("-splitscreen"))
+	{
+		autostart = true;
+		splitscreen = true;
+	}
+
 	// rei/miru: bootmap (Idea: starts the game on a predefined map)
 	if (bootmap && !(M_CheckParm("-warp") && M_IsNextParm()))
 	{


### PR DESCRIPTION
Running SRB2 with just `srb2 -splitscreen` within a command line prompt/terminal will immediately start the game in splitscreen mode.