### PR TITLE
Use spaces instead of tabs in Makefile.cfg

### DIFF
--- a/src/Makefile.cfg
+++ b/src/Makefile.cfg
@@ -61,10 +61,10 @@ ifeq   (,$(filter GCC% CLEANONLY,$(.VARIABLES)))
 
   # If this version is not in the list, default to the latest supported
   ifeq (,$(filter $(v),$(SUPPORTED_GCC_VERSIONS)))
-	define line =
+    define line =
 	Your compiler version, GCC $(version), is not supported by the Makefile.
 	The Makefile will assume GCC $(LATEST_GCC_VERSION).))
-	endef
+    endef
    $(call print,$(line))
    GCC$(subst .,,$(LATEST_GCC_VERSION))=1
   else


### PR DESCRIPTION
Hi.

Had some trouble compiling in Linux due to GCC version being too recent.
Problem were a few tab characters causing Makefile.cfg from parsing successfully and stopping the build pre-emptively.  
This fix substitutes spaces for those tabs.