### PR TITLE
Expose M_MapNumber to Lua

### DIFF
--- a/src/lua_baselib.c
+++ b/src/lua_baselib.c
@@ -28,6 +28,7 @@
 #include "console.h"
 #include "d_netcmd.h" // IsPlayerAdmin
 #include "m_menu.h" // Player Setup menu color stuff
+#include "m_misc.h" // M_MapNumber
 
 #include "lua_script.h"
 #include "lua_libs.h"
@@ -354,6 +355,23 @@ static int lib_pGetColorAfter(lua_State *L)
 {
 	UINT16 color = (UINT16)luaL_checkinteger(L, 1);
 	lua_pushinteger(L, M_GetColorAfter(color));
+	return 1;
+}
+
+// M_MISC
+//////////////
+
+static int lib_mMapNumber(lua_State *L)
+{
+	const char *arg = luaL_checkstring(L, 1);
+	size_t len = strlen(arg);
+	if (len == 2 || len == 5) {
+		char first = arg[len-2];
+		char second = arg[len-1];
+		lua_pushinteger(L, M_MapNumber(first, second));
+	} else {
+		lua_pushinteger(L, 0);
+	}
 	return 1;
 }
 
@@ -3777,6 +3795,9 @@ static luaL_Reg lib[] = {
 	{"M_MoveColorBefore",lib_pMoveColorBefore},
 	{"M_GetColorAfter",lib_pGetColorAfter},
 	{"M_GetColorBefore",lib_pGetColorBefore},
+
+	// m_misc
+	{"M_MapNumber",lib_mMapNumber},
 
 	// m_random
 	{"P_RandomFixed",lib_pRandomFixed},


### PR DESCRIPTION
I thought it was weird that `G_BuildMapName` was exposed to Lua and `M_MapNumber` wasn't. So I decided to add it.

I also noticed that `m_menu.h` was `#include`d twice in `lua_baselib.c`, but I'm not sure whether this was intentional or an oversight, or whether removing the wrong one would break something, so I didn't touch it.