### PR TITLE
fix ARM builds being completely broken

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -127,7 +127,9 @@ endif()
 # Compatibility flag with later versions of GCC
 # We should really fix our code to not need this
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-	target_compile_options(SRB2SDL2 PRIVATE -mno-ms-bitfields)
+	if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|x64|amd64|AMD64|em64t|EM64T)")
+		target_compile_options(SRB2SDL2 PRIVATE -mno-ms-bitfields)
+	endif()
 	target_compile_options(SRB2SDL2 PRIVATE -Wno-trigraphs)
 endif()
 


### PR DESCRIPTION
If merged, this is the quickest approach to resolve https://github.com/STJr/SRB2/issues/513

...alternatively, we could just remove the option altogether but I don't have the time right now to test whether it's needed or not

To the best of my knowledge, this covers all possible amd64 `CMAKE_SYSTEM_PROCESSOR` values based on what I'm seeing at https://stackoverflow.com/questions/70475665/what-are-the-possible-values-of-cmake-system-processor