### PR TITLE
src/sdl/i_system.c: Guard backtrace(3) behind glibc and *BSD

### DIFF
--- a/src/sdl/i_system.c
+++ b/src/sdl/i_system.c
@@ -137,7 +137,7 @@ typedef LPVOID (WINAPI *p_MapViewOfFile) (HANDLE, DWORD, DWORD, DWORD, SIZE_T);
 #include <errno.h>
 #endif
 
-#if defined (__unix__) || defined(__APPLE__) || defined (UNIXCOMMON)
+#if defined(__APPLE__) || defined (__GLIBC__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
 #include <execinfo.h>
 #include <time.h>
 #define UNIXBACKTRACE


### PR DESCRIPTION
Present in NetBSD 7.0+, OpenBSD 7.0+, FreeBSD 10.0+, DragonFlyBSD, GNU glibc 2.1+

Absent in POSIX and musl libc.
