### PR TITLE
Fix: Terminal not showing during screen wipes, but is updated.

### DIFF
--- a/src/f_wipe.c
+++ b/src/f_wipe.c
@@ -529,6 +529,7 @@ boolean F_TryColormapFade(UINT8 wipecolor)
   */
 void F_RunWipe(UINT8 wipetype, boolean drawMenu)
 {
+	CON_ToggleOff();//turn off console for the wipe
 #ifdef NOWIPE
 	(void)wipetype;
 	(void)drawMenu;


### PR DESCRIPTION
Bug reported on GitLab at: https://git.do.srb2.org/STJr/SRB2/-/issues/725
This bugs makes the terminal usable during a screen wipe, but it is hidden by the screen wipe. 
Automatic screen wipes, not associated with menu transitions, mostly occur at the start of the game. 
Given this circumstance and the various ways a screen wipe can occur, my solution to this problem is to simply disable the terminal if it is open before the wipe. 
This makes the game look more polished and prevents the player from making incorrect inputs during the wipe, when the terminal was hidden because of the wipe.
To do  this I used CON_ToggleOff at the start of the F_RunWipe, to close the terminal when a wipe occurs.