### PR TITLE
Fix: As knuckles, sometimes is impossible to move between adjacent walls. 

### DIFF
--- a/src/p_map.c
+++ b/src/p_map.c
@@ -3488,7 +3488,7 @@ static void PTR_GlideClimbTraverse(line_t *li)
 		canclimb = (li->backsector ? P_IsClimbingValid(slidemo->player, climbangle) : true);
 
 		if (((!slidemo->player->climbing && abs((signed)(slidemo->angle - ANGLE_90 - climbline)) < ANGLE_45)
-			|| (slidemo->player->climbing == 1 && abs((signed)(slidemo->angle - climbline)) < ANGLE_135))
+			|| (slidemo->player->climbing == 1 && abs((signed)(slidemo->angle - climbangle)) < ANGLE_135))
 			&& canclimb)
 		{
 			slidemo->angle = climbangle;


### PR DESCRIPTION
Bug reported on GitLab at: https://git.do.srb2.org/STJr/SRB2/-/issues/739
As knuckles, sometimes is impossible to move between adjacent walls. 
Happens when knuckles is climbing from left to right.
Due to a misused variable on src/p_map.c of the variable climbline instead of climbangle. Changing it resolves the problem.